### PR TITLE
Fixes the invisible FlexboxLayout

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
@@ -2585,6 +2585,64 @@ public class FlexboxAndroidTest {
 
     @Test
     @FlakyTest(tolerance = TOLERANCE)
+    public void testView_visibility_gone_first_item_in_flex_line_horizontal() throws Throwable {
+        // This test verifies if the FlexboxLayout is visible when the visibility of the first
+        // flex item in the second flex line (or arbitrary flex lines other than the first flex line)
+        // is set to "gone"
+        // There was an issue reported for that
+        // https://github.com/google/flexbox-layout/issues/47
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(
+                        R.layout.activity_visibility_gone_first_item_in_flex_line_row);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_ROW));
+        TextView textView1 = (TextView) activity.findViewById(R.id.text1);
+        TextView textView3 = (TextView) activity.findViewById(R.id.text3);
+
+        assertTrue(flexboxLayout.getHeight() > 0);
+        assertThat(flexboxLayout.getHeight(), is(textView1.getHeight() + textView3.getHeight()));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testView_visibility_gone_first_item_in_flex_line_vertical() throws Throwable {
+        // This test verifies if the FlexboxLayout is visible when the visibility of the first
+        // flex item in the second flex line (or arbitrary flex lines other than the first flex line)
+        // is set to "gone"
+        // There was an issue reported for that
+        // https://github.com/google/flexbox-layout/issues/47
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(
+                        R.layout.activity_visibility_gone_first_item_in_flex_line_column);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+        TextView textView1 = (TextView) activity.findViewById(R.id.text1);
+        TextView textView3 = (TextView) activity.findViewById(R.id.text3);
+
+        assertTrue(flexboxLayout.getWidth() > 0);
+        assertThat(flexboxLayout.getWidth(), is(textView1.getWidth() + textView3.getWidth()));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
     public void testView_visibility_invisible() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
         mActivityRule.runOnUiThread(new Runnable() {

--- a/flexbox/src/androidTest/res/layout/activity_visibility_gone_first_item_in_flex_line_column.xml
+++ b/flexbox/src/androidTest/res/layout/activity_visibility_gone_first_item_in_flex_line_column.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2016 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="wrap_content"
+    android:layout_height="360dp"
+    app:flexDirection="column"
+    app:flexWrap="wrap">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="wrap_content"
+        android:layout_height="160dp"
+        android:text="1" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="wrap_content"
+        android:layout_height="160dp"
+        android:text="2" />
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="wrap_content"
+        android:layout_height="160dp"
+        android:visibility="gone"
+        android:text="3" />
+
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/androidTest/res/layout/activity_visibility_gone_first_item_in_flex_line_row.xml
+++ b/flexbox/src/androidTest/res/layout/activity_visibility_gone_first_item_in_flex_line_row.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2016 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="360dp"
+    android:layout_height="wrap_content"
+    app:flexDirection="row"
+    app:flexWrap="wrap">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="160dp"
+        android:layout_height="wrap_content"
+        android:text="1" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="160dp"
+        android:layout_height="wrap_content"
+        android:text="2" />
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="160dp"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:text="3" />
+
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
@@ -442,9 +442,11 @@ public class FlexboxLayout extends ViewGroup {
             for (int i = 0; i < childCount; i++) {
                 View child = getReorderedChildAt(i);
                 if (child == null) {
+                    addFlexLineIfLastFlexItem(i, childCount, paddingEnd, flexLine);
                     continue;
                 } else if (child.getVisibility() == View.GONE) {
                     flexLine.itemCount++;
+                    addFlexLineIfLastFlexItem(i, childCount, paddingEnd, flexLine);
                     continue;
                 }
 
@@ -519,11 +521,7 @@ public class FlexboxLayout extends ViewGroup {
                                     child.getMeasuredHeight() - child.getBaseline()
                                             + lp.bottomMargin);
                 }
-                if (i == childCount - 1 && flexLine.itemCount != 0) {
-                    // Add the flex line if this item is the last item
-                    flexLine.mainSize += paddingEnd;
-                    mFlexLines.add(flexLine);
-                }
+                addFlexLineIfLastFlexItem(i, childCount, paddingEnd, flexLine);
             }
         }
 
@@ -595,9 +593,11 @@ public class FlexboxLayout extends ViewGroup {
         for (int i = 0; i < childCount; i++) {
             View child = getReorderedChildAt(i);
             if (child == null) {
+                addFlexLineIfLastFlexItem(i, childCount, paddingBottom, flexLine);
                 continue;
             } else if (child.getVisibility() == View.GONE) {
                 flexLine.itemCount++;
+                addFlexLineIfLastFlexItem(i, childCount, paddingBottom, flexLine);
                 continue;
             }
 
@@ -660,11 +660,7 @@ public class FlexboxLayout extends ViewGroup {
             // later
             flexLine.crossSize = Math.max(flexLine.crossSize, largestWidthInColumn);
 
-            if (i == childCount - 1 && flexLine.itemCount != 0) {
-                // Add the flex line if this item is the last item
-                flexLine.mainSize += paddingBottom;
-                mFlexLines.add(flexLine);
-            }
+            addFlexLineIfLastFlexItem(i, childCount, paddingBottom, flexLine);
         }
 
         determineMainSize(mFlexDirection, widthMeasureSpec, heightMeasureSpec);
@@ -674,6 +670,15 @@ public class FlexboxLayout extends ViewGroup {
         stretchViews(mFlexDirection, mAlignItems);
         setMeasuredDimensionForFlex(mFlexDirection, widthMeasureSpec, heightMeasureSpec,
                 childState);
+    }
+
+    private void addFlexLineIfLastFlexItem(int childIndex, int childCount, int paddingToAdd,
+            FlexLine flexLine) {
+        if (childIndex == childCount - 1 && flexLine.itemCount != 0) {
+            // Add the flex line if this item is the last item
+            flexLine.mainSize += paddingToAdd;
+            mFlexLines.add(flexLine);
+        }
     }
 
     /**


### PR DESCRIPTION
If a flex item's visibility is gone which is the first flex item in the second flex line (or any flex lines other than the first one), the flex line in process is not added to the flex container.

Thus, if there are two flex lines, and the first flex item's visibility in the second line is gone, the FlexboxLayout became invisible.

Fixes #47 