### PR TITLE
Set the default values for layout_maxWidth/layout_maxHeight 

### DIFF
--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
@@ -1884,6 +1884,8 @@ public class FlexboxLayout extends ViewGroup {
 
         public static final int ALIGN_SELF_STRETCH = ALIGN_ITEMS_STRETCH;
 
+        private static final int MAX_SIZE = Integer.MAX_VALUE & ViewCompat.MEASURED_SIZE_MASK;
+
         /**
          * This attribute can change the ordering of the children views are laid out.
          * By default, children are displayed and laid out in the same order as they appear in the
@@ -1942,12 +1944,12 @@ public class FlexboxLayout extends ViewGroup {
         /**
          * This attribute determines the maximum width the child can expand to.
          */
-        public int maxWidth = Integer.MAX_VALUE;
+        public int maxWidth = MAX_SIZE;
 
         /**
          * This attribute determines the maximum height the child can expand to.
          */
-        public int maxHeight = Integer.MAX_VALUE;
+        public int maxHeight = MAX_SIZE;
 
         public LayoutParams(Context context, AttributeSet attrs) {
             super(context, attrs);
@@ -1968,9 +1970,9 @@ public class FlexboxLayout extends ViewGroup {
             minHeight = a
                     .getDimensionPixelSize(R.styleable.FlexboxLayout_Layout_layout_minHeight, 0);
             maxWidth = a.getDimensionPixelSize(R.styleable.FlexboxLayout_Layout_layout_maxWidth,
-                    Integer.MAX_VALUE);
+                    MAX_SIZE);
             maxHeight = a.getDimensionPixelSize(R.styleable.FlexboxLayout_Layout_layout_maxHeight,
-                    Integer.MAX_VALUE);
+                    MAX_SIZE);
             a.recycle();
         }
 


### PR DESCRIPTION
As the value masked by ViewCompat.MEASURED_SIZE_MASK since the view size can't be beyond
that value and otherwise Android Studio warns in the MeasureSpec.makeMeasureSpec
if there is a possibility an argument is passed beyond the value is passed.

