### PR TITLE
Remove the installatoin of the build-tools 23.0.3 during the CI build.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,6 @@ machine:
 
 dependencies:
     pre:
-        - echo y | android update sdk --no-ui --all --filter "build-tools-23.0.3"
         # For some reasons, there is an issue with the pre-installed gcloud that
         # PyOpenSSL is not available when trying to activate the service account.
         # Re-installing the gcloud worked as a workaround.


### PR DESCRIPTION
The default linux container for Circle CI was upgraded, that has
the build-tools 23.0.3 by default.
