### PR TITLE
Fixes the issue #62

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
@@ -2849,6 +2849,36 @@ public class FlexboxAndroidTest {
         assertThat(flexboxLayout.getChildCount(), is(0));
     }
 
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testParentPadding_children_wrap_content() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_parent_padding_children_wrap_content);
+            }
+        });
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_ROW));
+        assertThat(flexboxLayout.getAlignItems(), is(FlexboxLayout.ALIGN_ITEMS_FLEX_START));
+        onView(withId(R.id.text1)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text1)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isRightOf(withId(R.id.text1)));
+        onView(withId(R.id.text2)).check(isBottomAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text3)).check(isBelow(withId(R.id.text1)));
+        onView(withId(R.id.text3)).check(isBelow(withId(R.id.text2)));
+        onView(withId(R.id.text3)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text2 = (TextView) activity.findViewById(R.id.text2);
+        // The second TextView's height should be larger than the first one because otherwise the
+        // text in the second one doesn't fit in the first flex line (because of parrent padding)
+        assertTrue(text1.getHeight() < text2.getHeight());
+    }
+
     private TextView createTextView(Context context, String text, int order) {
         TextView textView = new TextView(context);
         textView.setText(text);

--- a/flexbox/src/androidTest/res/layout/activity_parent_padding_children_wrap_content.xml
+++ b/flexbox/src/androidTest/res/layout/activity_parent_padding_children_wrap_content.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2016 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="360dp"
+    android:layout_height="300dp"
+    android:padding="16dp"
+    app:flexWrap="wrap"
+    app:alignItems="flex_start">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="1"
+        android:layout_margin="-16dp"
+        app:layout_flexBasisPercent="100%" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="2222" />
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="160dp"
+        android:layout_height="120dp"
+        android:text="3" />
+</com.google.android.flexbox.FlexboxLayout>


### PR DESCRIPTION
This fixes the edge case where the child's width is WRAP_CONTENT and some
of the contents along the main axis would be truncated if parent's padding
is added (if this is the case, remeasure the child with accumulated width
taken into account to avoid some of the contents to be truncated).
Because accumulated width is not taken into account in the first
measurement of each child (because FlexboxLayout has the concept of wrapping,
at the first measurement of each child, we want the child to be big as it
wants even if there is not enough left over space)

