### PR TITLE
Fixes #62.

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
@@ -2836,6 +2836,110 @@ public class FlexboxAndroidTest {
 
     @Test
     @FlakyTest(tolerance = TOLERANCE)
+    public void testWrap_parentPadding_horizontal() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_wrap_parent_padding_horizontal_test);
+            }
+        });
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_ROW));
+        // The sum of width of TextView1 and TextView2 is not enough for wrapping, but considering
+        // parent padding, the second TextView should be wrapped
+        onView(withId(R.id.text2)).check(isBelow(withId(R.id.text1)));
+        onView(withId(R.id.text3)).check(isRightOf(withId(R.id.text2)));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text2 = (TextView) activity.findViewById(R.id.text2);
+        assertThat(flexboxLayout.getHeight(),
+                is(flexboxLayout.getPaddingTop() + flexboxLayout.getPaddingBottom() +
+                        text1.getHeight() + text2.getHeight()));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testWrap_parentPadding_vertical() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_wrap_parent_padding_vertical_test);
+            }
+        });
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+        // The sum of height of TextView1 and TextView2 is not enough for wrapping, but considering
+        // parent padding, the second TextView should be wrapped
+        onView(withId(R.id.text2)).check(isRightOf(withId(R.id.text1)));
+        onView(withId(R.id.text3)).check(isBelow(withId(R.id.text2)));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text2 = (TextView) activity.findViewById(R.id.text2);
+        assertThat(flexboxLayout.getWidth(),
+                is(flexboxLayout.getPaddingLeft() + flexboxLayout.getPaddingRight() +
+                        text1.getWidth() + text2.getWidth()));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testWrap_childMargin_horizontal() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_wrap_child_margin_horizontal_test);
+            }
+        });
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_ROW));
+        // The sum of width of TextView1 and TextView2 is not enough for wrapping, but considering
+        // the margin for the TextView2, the second TextView should be wrapped
+        onView(withId(R.id.text2)).check(isBelow(withId(R.id.text1)));
+        onView(withId(R.id.text3)).check(isRightOf(withId(R.id.text2)));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text2 = (TextView) activity.findViewById(R.id.text2);
+        FlexboxLayout.LayoutParams lp2 = (FlexboxLayout.LayoutParams) text2.getLayoutParams();
+        assertThat(flexboxLayout.getHeight(),
+                is(text1.getHeight() + text2.getHeight() + lp2.topMargin + lp2.bottomMargin));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testWrap_childMargin_vertical() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_wrap_child_margin_vertical_test);
+            }
+        });
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+        // The sum of height of TextView1 and TextView2 is not enough for wrapping, but considering
+        // the margin of the TextView2, the second TextView should be wrapped
+        onView(withId(R.id.text2)).check(isRightOf(withId(R.id.text1)));
+        onView(withId(R.id.text3)).check(isBelow(withId(R.id.text2)));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text2 = (TextView) activity.findViewById(R.id.text2);
+        FlexboxLayout.LayoutParams lp2 = (FlexboxLayout.LayoutParams) text2.getLayoutParams();
+        assertThat(flexboxLayout.getWidth(),
+                is(text1.getWidth() + text2.getWidth() + lp2.leftMargin + lp2.rightMargin));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
     public void testEmptyChildren() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
         mActivityRule.runOnUiThread(new Runnable() {

--- a/flexbox/src/androidTest/res/layout/activity_wrap_child_margin_horizontal_test.xml
+++ b/flexbox/src/androidTest/res/layout/activity_wrap_child_margin_horizontal_test.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2016 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="360dp"
+    android:layout_height="wrap_content"
+    app:flexDirection="row"
+    app:flexWrap="wrap"
+    app:alignItems="flex_start">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="280dp"
+        android:layout_height="80dp"
+        android:text="1" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="30dp"
+        android:layout_height="80dp"
+        android:layout_margin="32dp"
+        android:text="2" />
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="100dp"
+        android:layout_height="80dp"
+        android:text="3" />
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/androidTest/res/layout/activity_wrap_child_margin_vertical_test.xml
+++ b/flexbox/src/androidTest/res/layout/activity_wrap_child_margin_vertical_test.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2016 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="wrap_content"
+    android:layout_height="360dp"
+    app:flexDirection="column"
+    app:flexWrap="wrap"
+    app:alignItems="flex_start">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="80dp"
+        android:layout_height="280dp"
+        android:text="1" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="80dp"
+        android:layout_height="30dp"
+        android:layout_margin="32dp"
+        android:text="2" />
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        android:text="3" />
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/androidTest/res/layout/activity_wrap_parent_padding_horizontal_test.xml
+++ b/flexbox/src/androidTest/res/layout/activity_wrap_parent_padding_horizontal_test.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2016 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="360dp"
+    android:layout_height="wrap_content"
+    android:padding="32dp"
+    app:flexDirection="row"
+    app:flexWrap="wrap"
+    app:alignItems="flex_start">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="280dp"
+        android:layout_height="80dp"
+        android:text="1" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="30dp"
+        android:layout_height="80dp"
+        android:text="2" />
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="100dp"
+        android:layout_height="80dp"
+        android:text="3" />
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/androidTest/res/layout/activity_wrap_parent_padding_vertical_test.xml
+++ b/flexbox/src/androidTest/res/layout/activity_wrap_parent_padding_vertical_test.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2016 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="wrap_content"
+    android:layout_height="360dp"
+    android:padding="32dp"
+    app:flexDirection="column"
+    app:flexWrap="wrap"
+    app:alignItems="flex_start">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="80dp"
+        android:layout_height="280dp"
+        android:text="1" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="80dp"
+        android:layout_height="30dp"
+        android:text="2" />
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        android:text="3" />
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
@@ -448,15 +448,15 @@ public class FlexboxLayout extends ViewGroup {
             int paddingEnd = ViewCompat.getPaddingEnd(this);
             int largestHeightInRow = Integer.MIN_VALUE;
             FlexLine flexLine = new FlexLine();
-            flexLine.mainSize = paddingStart;
+            flexLine.mainSize = paddingStart + paddingEnd;
             for (int i = 0; i < childCount; i++) {
                 View child = getReorderedChildAt(i);
                 if (child == null) {
-                    addFlexLineIfLastFlexItem(i, childCount, paddingEnd, flexLine);
+                    addFlexLineIfLastFlexItem(i, childCount, flexLine);
                     continue;
                 } else if (child.getVisibility() == View.GONE) {
                     flexLine.itemCount++;
-                    addFlexLineIfLastFlexItem(i, childCount, paddingEnd, flexLine);
+                    addFlexLineIfLastFlexItem(i, childCount, flexLine);
                     continue;
                 }
 
@@ -498,13 +498,12 @@ public class FlexboxLayout extends ViewGroup {
                         child.getMeasuredHeight() + lp.topMargin + lp.bottomMargin);
 
                 if (isWrapRequired(mFlexWrap, widthMode, widthSize, flexLine.mainSize,
-                        child.getMeasuredWidth(), lp)) {
-                    flexLine.mainSize += paddingEnd;
+                        child.getMeasuredWidth() + lp.leftMargin + lp.rightMargin, lp)) {
                     mFlexLines.add(flexLine);
 
                     flexLine = new FlexLine();
                     flexLine.itemCount = 1;
-                    flexLine.mainSize = paddingStart;
+                    flexLine.mainSize = paddingStart + paddingEnd;
                     largestHeightInRow = child.getMeasuredHeight() + lp.topMargin + lp.bottomMargin;
                 } else {
                     flexLine.itemCount++;
@@ -530,7 +529,7 @@ public class FlexboxLayout extends ViewGroup {
                                     child.getMeasuredHeight() - child.getBaseline()
                                             + lp.bottomMargin);
                 }
-                addFlexLineIfLastFlexItem(i, childCount, paddingEnd, flexLine);
+                addFlexLineIfLastFlexItem(i, childCount, flexLine);
             }
         }
 
@@ -599,15 +598,15 @@ public class FlexboxLayout extends ViewGroup {
         int paddingBottom = getPaddingBottom();
         int largestWidthInColumn = Integer.MIN_VALUE;
         FlexLine flexLine = new FlexLine();
-        flexLine.mainSize = paddingTop;
+        flexLine.mainSize = paddingTop + paddingBottom;
         for (int i = 0; i < childCount; i++) {
             View child = getReorderedChildAt(i);
             if (child == null) {
-                addFlexLineIfLastFlexItem(i, childCount, paddingBottom, flexLine);
+                addFlexLineIfLastFlexItem(i, childCount, flexLine);
                 continue;
             } else if (child.getVisibility() == View.GONE) {
                 flexLine.itemCount++;
-                addFlexLineIfLastFlexItem(i, childCount, paddingBottom, flexLine);
+                addFlexLineIfLastFlexItem(i, childCount, flexLine);
                 continue;
             }
 
@@ -649,13 +648,12 @@ public class FlexboxLayout extends ViewGroup {
                     child.getMeasuredWidth() + lp.leftMargin + lp.rightMargin);
 
             if (isWrapRequired(mFlexWrap, heightMode, heightSize, flexLine.mainSize,
-                    child.getMeasuredHeight(), lp)) {
-                flexLine.mainSize += paddingBottom;
+                    child.getMeasuredHeight() + lp.topMargin + lp.bottomMargin, lp)) {
                 mFlexLines.add(flexLine);
 
                 flexLine = new FlexLine();
                 flexLine.itemCount = 1;
-                flexLine.mainSize = paddingTop;
+                flexLine.mainSize = paddingTop + paddingBottom;
                 largestWidthInColumn = child.getMeasuredWidth() + lp.leftMargin
                         + lp.rightMargin;
             } else {
@@ -669,7 +667,7 @@ public class FlexboxLayout extends ViewGroup {
             // later
             flexLine.crossSize = Math.max(flexLine.crossSize, largestWidthInColumn);
 
-            addFlexLineIfLastFlexItem(i, childCount, paddingBottom, flexLine);
+            addFlexLineIfLastFlexItem(i, childCount, flexLine);
         }
 
         determineMainSize(mFlexDirection, widthMeasureSpec, heightMeasureSpec);
@@ -715,11 +713,9 @@ public class FlexboxLayout extends ViewGroup {
         }
     }
 
-    private void addFlexLineIfLastFlexItem(int childIndex, int childCount, int paddingToAdd,
-            FlexLine flexLine) {
+    private void addFlexLineIfLastFlexItem(int childIndex, int childCount, FlexLine flexLine) {
         if (childIndex == childCount - 1 && flexLine.itemCount != 0) {
             // Add the flex line if this item is the last item
-            flexLine.mainSize += paddingToAdd;
             mFlexLines.add(flexLine);
         }
     }


### PR DESCRIPTION
To judge the line wrapping, the padding value from the parent and the margin
of the child being processed were missing.
This PR adds those values when judging if a new flex line is required.