### PR TITLE
Take the parent padding into account when determining the cross size.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         // NOTE: Do not place your application dependencies here; they belong

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
@@ -1336,6 +1336,58 @@ public class FlexboxAndroidTest {
 
     @Test
     @FlakyTest(tolerance = TOLERANCE)
+    public void testAlignContent_flexEnd_parentPadding() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_align_content_test);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                flexboxLayout.setAlignContent(FlexboxLayout.ALIGN_CONTENT_FLEX_END);
+                flexboxLayout.setPadding(32, 32, 32, 32);
+            }
+        });
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        assertThat(flexboxLayout.getAlignContent(), is(FlexboxLayout.ALIGN_CONTENT_FLEX_END));
+        onView(withId(R.id.text1)).check(isAbove(withId(R.id.text3)));
+        onView(withId(R.id.text2)).check(isAbove(withId(R.id.text3)));
+
+        TextView textView3 = (TextView) activity.findViewById(R.id.text3);
+        assertThat(textView3.getBottom(),
+                is(flexboxLayout.getBottom() - flexboxLayout.getPaddingBottom()));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testAlignContent_flexEnd_parentPadding_column() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_align_content_test);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                flexboxLayout.setAlignContent(FlexboxLayout.ALIGN_CONTENT_FLEX_END);
+                flexboxLayout.setFlexDirection(FlexboxLayout.FLEX_DIRECTION_COLUMN);
+                flexboxLayout.setPadding(32, 32, 32, 32);
+            }
+        });
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        assertThat(flexboxLayout.getAlignContent(), is(FlexboxLayout.ALIGN_CONTENT_FLEX_END));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+        onView(withId(R.id.text1)).check(isLeftOf(withId(R.id.text3)));
+        onView(withId(R.id.text2)).check(isLeftOf(withId(R.id.text3)));
+
+        TextView textView3 = (TextView) activity.findViewById(R.id.text3);
+        assertThat(textView3.getRight(),
+                is(flexboxLayout.getRight() - flexboxLayout.getPaddingRight()));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
     public void testAlignContent_center() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
         mActivityRule.runOnUiThread(new Runnable() {
@@ -1877,6 +1929,60 @@ public class FlexboxAndroidTest {
         assertTrue(flexLineSize - 1 <= textView2.getBottom() &&
                 textView2.getBottom() <= flexLineSize + 1);
         assertThat(textView3.getBottom(), is(flexboxLayout.getBottom()));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testAlignItems_flexEnd_parentPadding() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_align_items_parent_padding_test);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                flexboxLayout.setAlignItems(FlexboxLayout.ALIGN_ITEMS_FLEX_END);
+            }
+        });
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        assertThat(flexboxLayout.getAlignItems(), is(FlexboxLayout.ALIGN_ITEMS_FLEX_END));
+        onView(withId(R.id.text2)).check(isRightOf(withId(R.id.text1)));
+
+        TextView textView1 = (TextView) activity.findViewById(R.id.text1);
+        TextView textView2 = (TextView) activity.findViewById(R.id.text2);
+        assertThat(textView1.getBottom(),
+                is(flexboxLayout.getBottom() - flexboxLayout.getPaddingBottom()));
+        assertThat(textView2.getBottom(),
+                is(flexboxLayout.getBottom() - flexboxLayout.getPaddingBottom()));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testAlignItems_flexEnd_parentPadding_column() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_align_items_parent_padding_test);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                flexboxLayout.setAlignItems(FlexboxLayout.ALIGN_ITEMS_FLEX_END);
+                flexboxLayout.setFlexDirection(FlexboxLayout.FLEX_DIRECTION_COLUMN);
+            }
+        });
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        assertThat(flexboxLayout.getAlignItems(), is(FlexboxLayout.ALIGN_ITEMS_FLEX_END));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+        onView(withId(R.id.text2)).check(isBelow(withId(R.id.text1)));
+
+        TextView textView1 = (TextView) activity.findViewById(R.id.text1);
+        TextView textView2 = (TextView) activity.findViewById(R.id.text2);
+        assertThat(textView1.getRight(),
+                is(flexboxLayout.getRight() - flexboxLayout.getPaddingRight()));
+        assertThat(textView2.getRight(),
+                is(flexboxLayout.getRight() - flexboxLayout.getPaddingRight()));
     }
 
     @Test

--- a/flexbox/src/androidTest/res/layout/activity_align_items_parent_padding_test.xml
+++ b/flexbox/src/androidTest/res/layout/activity_align_items_parent_padding_test.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2016 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="320dp"
+    android:layout_height="320dp"
+    android:padding="16dp"
+    app:flexDirection="row"
+    app:flexWrap="wrap"
+    app:alignItems="flex_end">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:text="1" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:text="2" />
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
@@ -562,7 +562,8 @@ public class FlexboxLayout extends ViewGroup {
             }
         }
 
-        determineCrossSize(mFlexDirection, widthMeasureSpec, heightMeasureSpec);
+        determineCrossSize(mFlexDirection, widthMeasureSpec, heightMeasureSpec,
+                getPaddingTop() + getPaddingBottom());
         // Now cross size for each flex line is determined.
         // Expand the views if alignItems (or alignSelf in each child view) is set to stretch
         stretchViews(mFlexDirection, mAlignItems);
@@ -671,7 +672,8 @@ public class FlexboxLayout extends ViewGroup {
         }
 
         determineMainSize(mFlexDirection, widthMeasureSpec, heightMeasureSpec);
-        determineCrossSize(mFlexDirection, widthMeasureSpec, heightMeasureSpec);
+        determineCrossSize(mFlexDirection, widthMeasureSpec, heightMeasureSpec,
+                getPaddingLeft() + getPaddingRight());
         // Now cross size for each flex line is determined.
         // Expand the views if alignItems (or alignSelf in each child view) is set to stretch
         stretchViews(mFlexDirection, mAlignItems);
@@ -1015,16 +1017,17 @@ public class FlexboxLayout extends ViewGroup {
      * Expand the cross size only if the height mode is MeasureSpec.EXACTLY, otherwise
      * use the sum of cross sizes of all flex lines.
      *
-     * @param flexDirection     the flex direction attribute
-     * @param widthMeasureSpec  horizontal space requirements as imposed by the parent
-     * @param heightMeasureSpec vertical space requirements as imposed by the parent
+     * @param flexDirection         the flex direction attribute
+     * @param widthMeasureSpec      horizontal space requirements as imposed by the parent
+     * @param heightMeasureSpec     vertical space requirements as imposed by the parent
+     * @param paddingAlongCrossAxis the padding value for the FlexboxLayout along the cross axis
      * @see #getFlexDirection()
      * @see #setFlexDirection(int)
      * @see #getAlignContent()
      * @see #setAlignContent(int)
      */
     private void determineCrossSize(int flexDirection, int widthMeasureSpec,
-            int heightMeasureSpec) {
+            int heightMeasureSpec, int paddingAlongCrossAxis) {
         // The MeasureSpec mode along the cross axis
         int mode;
         // The MeasureSpec size along the cross axis
@@ -1044,9 +1047,9 @@ public class FlexboxLayout extends ViewGroup {
                 throw new IllegalArgumentException("Invalid flex direction: " + flexDirection);
         }
         if (mode == MeasureSpec.EXACTLY) {
-            int totalCrossSize = getSumOfCrossSize();
+            int totalCrossSize = getSumOfCrossSize() + paddingAlongCrossAxis;
             if (mFlexLines.size() == 1) {
-                mFlexLines.get(0).crossSize = size;
+                mFlexLines.get(0).crossSize = size - paddingAlongCrossAxis;
                 // alignContent property is valid only if the Flexbox has at least two lines
             } else if (mFlexLines.size() >= 2 && totalCrossSize < size) {
                 switch (mAlignContent) {


### PR DESCRIPTION
Fixes #72.
Including changes:
- Update the build tools version.
- Take the parent padding value into account when determining the cross size.
