### PR TITLE
Add a copy constructor for the layout parameters

### DIFF
--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
@@ -2024,6 +2024,21 @@ public class FlexboxLayout extends ViewGroup {
             a.recycle();
         }
 
+        public LayoutParams(LayoutParams source) {
+            super(source);
+
+            order = source.order;
+            flexGrow = source.flexGrow;
+            flexShrink = source.flexShrink;
+            alignSelf = source.alignSelf;
+            flexBasisPercent = source.flexBasisPercent;
+            minWidth = source.minWidth;
+            minHeight = source.minHeight;
+            maxWidth = source.maxWidth;
+            maxHeight = source.maxHeight;
+            wrapBefore = source.wrapBefore;
+        }
+
         public LayoutParams(ViewGroup.LayoutParams source) {
             super(source);
         }


### PR DESCRIPTION
Both the base LayoutParams and ViewGroup's implement a copy constructor, which is handy for a lot of cases.
Calling the copy constructor on FlexboxLayout.LayoutParams does not produce the expected result: parent properties are properly copied, but any FlexboxLayout specific attribute is ignored.

This pull requests adds a new copy constructor to FlexboxLayout's LayoutParams, making it behave as expected.