### PR TITLE
Add divider implementation

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
@@ -26,12 +26,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.ViewAssertion;
-import android.support.test.espresso.assertion.ViewAssertions;
 import android.support.test.filters.MediumTest;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
+import android.support.v4.content.res.ResourcesCompat;
 import android.test.FlakyTest;
 import android.view.View;
 import android.view.ViewGroup;
@@ -46,6 +47,7 @@ import static android.support.test.espresso.assertion.PositionAssertions.isLeftO
 import static android.support.test.espresso.assertion.PositionAssertions.isRightAlignedWith;
 import static android.support.test.espresso.assertion.PositionAssertions.isRightOf;
 import static android.support.test.espresso.assertion.PositionAssertions.isTopAlignedWith;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
@@ -2919,7 +2921,8 @@ public class FlexboxAndroidTest {
             @Override
             public void run() {
                 activity.setContentView(R.layout.activity_wrap_before_test);
-                FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
                 flexboxLayout.setFlexWrap(FlexboxLayout.FLEX_WRAP_NOWRAP);
             }
         });
@@ -3125,6 +3128,670 @@ public class FlexboxAndroidTest {
         assertThat(flexboxLayout.getChildCount(), is(0));
     }
 
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionRow_verticalBeginning() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_row);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_ROW));
+        assertThat(flexboxLayout.getShowDividerVertical(),
+                is(FlexboxLayout.SHOW_DIVIDER_BEGINNING));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text2 = (TextView) activity.findViewById(R.id.text2);
+        TextView text3 = (TextView) activity.findViewById(R.id.text3);
+        Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider, null);
+        assertNotNull(divider);
+        int widthSumFirstRow = text1.getWidth() + text2.getWidth() + text3.getWidth() + divider
+                .getIntrinsicWidth();
+        assertThat(text3.getRight(), is(widthSumFirstRow));
+        assertThat(text1.getLeft(), is(not(flexboxLayout.getLeft())));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionRow_verticalMiddle() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_row);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                flexboxLayout.setShowDividerVertical(FlexboxLayout.SHOW_DIVIDER_MIDDLE);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_ROW));
+        assertThat(flexboxLayout.getShowDividerVertical(), is(FlexboxLayout.SHOW_DIVIDER_MIDDLE));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text2 = (TextView) activity.findViewById(R.id.text2);
+        TextView text3 = (TextView) activity.findViewById(R.id.text3);
+        Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider, null);
+        assertNotNull(divider);
+        // Three text views are placed in the first row, thus two vertical middle dividers should
+        // be placed
+        int widthSumFirstRow = text1.getWidth() + text2.getWidth() + text3.getWidth()
+                + divider.getIntrinsicWidth() * 2;
+        assertThat(text3.getRight(), is(widthSumFirstRow));
+        assertThat(text1.getLeft(), is(flexboxLayout.getLeft()));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionRow_verticalEnd() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_row);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                flexboxLayout.setShowDividerVertical(FlexboxLayout.SHOW_DIVIDER_END);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_ROW));
+        assertThat(flexboxLayout.getShowDividerVertical(), is(FlexboxLayout.SHOW_DIVIDER_END));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text2 = (TextView) activity.findViewById(R.id.text2);
+        TextView text3 = (TextView) activity.findViewById(R.id.text3);
+        Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider, null);
+        assertNotNull(divider);
+        // Three text views are placed in the first row, thus two vertical middle dividers should
+        // be placed
+        int widthSumFirstRow = text1.getWidth() + text2.getWidth() + text3.getWidth()
+                + divider.getIntrinsicWidth();
+        assertThat(text3.getRight() + divider.getIntrinsicWidth(), is(widthSumFirstRow));
+        assertThat(text1.getLeft(), is(flexboxLayout.getLeft()));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionRow_verticalAll() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_row);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                flexboxLayout.setShowDividerVertical(
+                        FlexboxLayout.SHOW_DIVIDER_BEGINNING | FlexboxLayout.SHOW_DIVIDER_MIDDLE
+                                | FlexboxLayout.SHOW_DIVIDER_END);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_ROW));
+        assertThat(flexboxLayout.getShowDividerVertical(),
+                is(FlexboxLayout.SHOW_DIVIDER_BEGINNING | FlexboxLayout.SHOW_DIVIDER_MIDDLE |
+                        FlexboxLayout.SHOW_DIVIDER_END));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text2 = (TextView) activity.findViewById(R.id.text2);
+        TextView text3 = (TextView) activity.findViewById(R.id.text3);
+        Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider, null);
+        assertNotNull(divider);
+        // Three text views are placed in the first row, thus two vertical middle dividers should
+        // be placed
+        int widthSumFirstRow = text1.getWidth() + text2.getWidth() + text3.getWidth()
+                + divider.getIntrinsicWidth() * 4;
+        assertThat(text3.getRight() + divider.getIntrinsicWidth(), is(widthSumFirstRow));
+        assertThat(text1.getLeft(), is(not(flexboxLayout.getLeft())));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionRow_horizontalBeginning() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        final Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider, null);
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_row);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                flexboxLayout.setDividerDrawableHorizontal(divider);
+                flexboxLayout.setShowDividerHorizontal(FlexboxLayout.SHOW_DIVIDER_BEGINNING);
+                flexboxLayout.setShowDividerVertical(FlexboxLayout.SHOW_DIVIDER_NONE);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_ROW));
+        assertThat(flexboxLayout.getShowDividerHorizontal(),
+                is(FlexboxLayout.SHOW_DIVIDER_BEGINNING));
+        assertThat(flexboxLayout.getShowDividerVertical(), is(FlexboxLayout.SHOW_DIVIDER_NONE));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text4 = (TextView) activity.findViewById(R.id.text4);
+        assertNotNull(divider);
+        int heightSum = text1.getHeight() + text4.getHeight() + divider.getIntrinsicHeight();
+        assertThat(text4.getBottom(), is(heightSum));
+        assertThat(text1.getTop(), is(not(flexboxLayout.getTop())));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionRow_horizontalMiddle() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_row);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                Drawable divider = ResourcesCompat
+                        .getDrawable(activity.getResources(), R.drawable.divider, null);
+                flexboxLayout.setDividerDrawableHorizontal(divider);
+                flexboxLayout.setShowDividerHorizontal(FlexboxLayout.SHOW_DIVIDER_MIDDLE);
+                flexboxLayout.setShowDividerVertical(FlexboxLayout.SHOW_DIVIDER_NONE);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_ROW));
+        assertThat(flexboxLayout.getShowDividerHorizontal(), is(FlexboxLayout.SHOW_DIVIDER_MIDDLE));
+        assertThat(flexboxLayout.getShowDividerVertical(), is(FlexboxLayout.SHOW_DIVIDER_NONE));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text4 = (TextView) activity.findViewById(R.id.text4);
+        Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider, null);
+        assertNotNull(divider);
+        int heightSum = text1.getHeight() + text4.getHeight() + divider.getIntrinsicHeight();
+        assertThat(text4.getBottom(), is(heightSum));
+        assertThat(text1.getTop(), is(flexboxLayout.getTop()));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionRow_horizontalEnd() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_row);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                Drawable divider = ResourcesCompat
+                        .getDrawable(activity.getResources(), R.drawable.divider, null);
+                flexboxLayout.setDividerDrawableHorizontal(divider);
+                flexboxLayout.setShowDividerHorizontal(FlexboxLayout.SHOW_DIVIDER_END);
+                flexboxLayout.setShowDividerVertical(FlexboxLayout.SHOW_DIVIDER_NONE);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_ROW));
+        assertThat(flexboxLayout.getShowDividerHorizontal(), is(FlexboxLayout.SHOW_DIVIDER_END));
+        assertThat(flexboxLayout.getShowDividerVertical(), is(FlexboxLayout.SHOW_DIVIDER_NONE));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text4 = (TextView) activity.findViewById(R.id.text4);
+        Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider, null);
+        assertNotNull(divider);
+        int heightSum = text1.getHeight() + text4.getHeight() + divider.getIntrinsicHeight();
+        assertThat(text4.getBottom() + divider.getIntrinsicHeight(), is(heightSum));
+        assertThat(text1.getTop(), is(flexboxLayout.getTop()));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionRow_horizontalAll() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_row);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                Drawable divider = ResourcesCompat
+                        .getDrawable(activity.getResources(), R.drawable.divider, null);
+                flexboxLayout.setDividerDrawableHorizontal(divider);
+                flexboxLayout.setShowDividerHorizontal(
+                        FlexboxLayout.SHOW_DIVIDER_BEGINNING | FlexboxLayout.SHOW_DIVIDER_MIDDLE
+                                | FlexboxLayout.SHOW_DIVIDER_END);
+                flexboxLayout.setShowDividerVertical(FlexboxLayout.SHOW_DIVIDER_NONE);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_ROW));
+        assertThat(flexboxLayout.getShowDividerHorizontal(),
+                is(FlexboxLayout.SHOW_DIVIDER_BEGINNING | FlexboxLayout.SHOW_DIVIDER_MIDDLE |
+                        FlexboxLayout.SHOW_DIVIDER_END));
+        assertThat(flexboxLayout.getShowDividerVertical(), is(FlexboxLayout.SHOW_DIVIDER_NONE));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text4 = (TextView) activity.findViewById(R.id.text4);
+        Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider, null);
+        assertNotNull(divider);
+        int heightSum = text1.getHeight() + text4.getHeight() + divider.getIntrinsicHeight() * 3;
+        assertThat(text4.getBottom() + divider.getIntrinsicHeight(), is(heightSum));
+        assertThat(text1.getTop(), is(not(flexboxLayout.getTop())));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionRow_all_thickDivider() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_row);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                Drawable thickDivider = ResourcesCompat
+                        .getDrawable(activity.getResources(), R.drawable.divider_thick, null);
+                flexboxLayout.setDividerDrawableVertical(thickDivider);
+                flexboxLayout.setShowDividerVertical(
+                        FlexboxLayout.SHOW_DIVIDER_BEGINNING | FlexboxLayout.SHOW_DIVIDER_MIDDLE
+                                | FlexboxLayout.SHOW_DIVIDER_END);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_ROW));
+        assertThat(flexboxLayout.getShowDividerVertical(),
+                is(FlexboxLayout.SHOW_DIVIDER_BEGINNING | FlexboxLayout.SHOW_DIVIDER_MIDDLE |
+                        FlexboxLayout.SHOW_DIVIDER_END));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text2 = (TextView) activity.findViewById(R.id.text2);
+        TextView text3 = (TextView) activity.findViewById(R.id.text3);
+        Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider_thick, null);
+        // The sum of three text views and the sum of thick dividers don't fit in one line.
+        // The last text view should be placed to the next line.
+        assertNotNull(divider);
+        int widthSumFirstRow = text1.getWidth() + text2.getWidth()
+                + divider.getIntrinsicWidth() * 3;
+        assertThat(text2.getRight() + divider.getIntrinsicWidth(), is(widthSumFirstRow));
+        assertThat(text1.getLeft(), is(not(flexboxLayout.getLeft())));
+        assertThat(text3.getBottom(), is(text1.getHeight() + text2.getHeight()));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionColumn_horizontalBeginning() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_column);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+        assertThat(flexboxLayout.getShowDividerHorizontal(),
+                is(FlexboxLayout.SHOW_DIVIDER_BEGINNING));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text2 = (TextView) activity.findViewById(R.id.text2);
+        TextView text3 = (TextView) activity.findViewById(R.id.text3);
+        Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider, null);
+        assertNotNull(divider);
+        int heightSumFirstRow = text1.getHeight() + text2.getHeight() + text3.getHeight() + divider
+                .getIntrinsicHeight();
+        assertThat(text3.getBottom(), is(heightSumFirstRow));
+        assertThat(text1.getTop(), is(not(flexboxLayout.getTop())));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionColumn_horizontalMiddle() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_column);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                flexboxLayout.setShowDividerHorizontal(FlexboxLayout.SHOW_DIVIDER_MIDDLE);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+        assertThat(flexboxLayout.getShowDividerHorizontal(), is(FlexboxLayout.SHOW_DIVIDER_MIDDLE));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text2 = (TextView) activity.findViewById(R.id.text2);
+        TextView text3 = (TextView) activity.findViewById(R.id.text3);
+        Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider, null);
+        assertNotNull(divider);
+        int heightSumFirstRow = text1.getHeight() + text2.getHeight() + text3.getHeight() + divider
+                .getIntrinsicHeight() * 2;
+        assertThat(text3.getBottom(), is(heightSumFirstRow));
+        assertThat(text1.getTop(), is(flexboxLayout.getTop()));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionColumn_horizontalEnd() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_column);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                flexboxLayout.setShowDividerHorizontal(FlexboxLayout.SHOW_DIVIDER_END);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+        assertThat(flexboxLayout.getShowDividerHorizontal(), is(FlexboxLayout.SHOW_DIVIDER_END));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text2 = (TextView) activity.findViewById(R.id.text2);
+        TextView text3 = (TextView) activity.findViewById(R.id.text3);
+        Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider, null);
+        assertNotNull(divider);
+        int heightSumFirstRow = text1.getHeight() + text2.getHeight() + text3.getHeight() + divider
+                .getIntrinsicHeight();
+        assertThat(text3.getBottom() + divider.getIntrinsicHeight(), is(heightSumFirstRow));
+        assertThat(text1.getTop(), is(flexboxLayout.getTop()));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionColumn_horizontalAll() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_column);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                flexboxLayout.setShowDividerHorizontal(
+                        FlexboxLayout.SHOW_DIVIDER_BEGINNING | FlexboxLayout.SHOW_DIVIDER_MIDDLE
+                                | FlexboxLayout.SHOW_DIVIDER_END);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+        assertThat(flexboxLayout.getShowDividerHorizontal(),
+                is(FlexboxLayout.SHOW_DIVIDER_BEGINNING | FlexboxLayout.SHOW_DIVIDER_MIDDLE |
+                        FlexboxLayout.SHOW_DIVIDER_END));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text2 = (TextView) activity.findViewById(R.id.text2);
+        TextView text3 = (TextView) activity.findViewById(R.id.text3);
+        Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider, null);
+        assertNotNull(divider);
+        int heightSumFirstRow = text1.getHeight() + text2.getHeight() + text3.getHeight() + divider
+                .getIntrinsicHeight() * 4;
+        assertThat(text3.getBottom() + divider.getIntrinsicHeight(), is(heightSumFirstRow));
+        assertThat(text1.getTop(), is(not(flexboxLayout.getTop())));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionColumn_verticalBeginning() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_column);
+                Drawable divider = ResourcesCompat
+                        .getDrawable(activity.getResources(), R.drawable.divider, null);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                flexboxLayout.setDividerDrawableVertical(divider);
+                flexboxLayout.setShowDividerVertical(FlexboxLayout.SHOW_DIVIDER_BEGINNING);
+                flexboxLayout.setShowDividerHorizontal(FlexboxLayout.SHOW_DIVIDER_NONE);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+        assertThat(flexboxLayout.getShowDividerVertical(),
+                is(FlexboxLayout.SHOW_DIVIDER_BEGINNING));
+        assertThat(flexboxLayout.getShowDividerHorizontal(), is(FlexboxLayout.SHOW_DIVIDER_NONE));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text4 = (TextView) activity.findViewById(R.id.text4);
+        Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider, null);
+        assertNotNull(divider);
+        int widthSum = text1.getWidth() + text4.getWidth() + divider.getIntrinsicWidth();
+        assertThat(text4.getRight(), is(widthSum));
+        assertThat(text1.getLeft(), is(not(flexboxLayout.getLeft())));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionColumn_verticalMiddle() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_column);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                Drawable divider = ResourcesCompat
+                        .getDrawable(activity.getResources(), R.drawable.divider, null);
+                flexboxLayout.setDividerDrawableVertical(divider);
+                flexboxLayout.setShowDividerVertical(FlexboxLayout.SHOW_DIVIDER_MIDDLE);
+                flexboxLayout.setShowDividerHorizontal(FlexboxLayout.SHOW_DIVIDER_NONE);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+        assertThat(flexboxLayout.getShowDividerVertical(), is(FlexboxLayout.SHOW_DIVIDER_MIDDLE));
+        assertThat(flexboxLayout.getShowDividerHorizontal(), is(FlexboxLayout.SHOW_DIVIDER_NONE));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text4 = (TextView) activity.findViewById(R.id.text4);
+        Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider, null);
+        assertNotNull(divider);
+        int widthSum = text1.getWidth() + text4.getWidth() + divider.getIntrinsicWidth();
+        assertThat(text4.getRight(), is(widthSum));
+        assertThat(text1.getLeft(), is(flexboxLayout.getLeft()));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionColumn_verticalEnd() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_column);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                Drawable divider = ResourcesCompat
+                        .getDrawable(activity.getResources(), R.drawable.divider, null);
+                flexboxLayout.setDividerDrawableHorizontal(divider);
+                flexboxLayout.setShowDividerVertical(FlexboxLayout.SHOW_DIVIDER_END);
+                flexboxLayout.setShowDividerHorizontal(FlexboxLayout.SHOW_DIVIDER_NONE);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+        assertThat(flexboxLayout.getShowDividerVertical(), is(FlexboxLayout.SHOW_DIVIDER_END));
+        assertThat(flexboxLayout.getShowDividerHorizontal(), is(FlexboxLayout.SHOW_DIVIDER_NONE));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text4 = (TextView) activity.findViewById(R.id.text4);
+        Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider, null);
+        assertNotNull(divider);
+        int widthSum = text1.getWidth() + text4.getWidth() + divider.getIntrinsicWidth();
+        assertThat(text4.getRight() + divider.getIntrinsicWidth(), is(widthSum));
+        assertThat(text1.getLeft(), is(flexboxLayout.getLeft()));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionColumn_verticalAll() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_column);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                Drawable divider = ResourcesCompat
+                        .getDrawable(activity.getResources(), R.drawable.divider, null);
+                flexboxLayout.setDividerDrawableVertical(divider);
+                flexboxLayout.setShowDividerVertical(
+                        FlexboxLayout.SHOW_DIVIDER_BEGINNING | FlexboxLayout.SHOW_DIVIDER_MIDDLE
+                                | FlexboxLayout.SHOW_DIVIDER_END);
+                flexboxLayout.setShowDividerHorizontal(FlexboxLayout.SHOW_DIVIDER_NONE);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+        assertThat(flexboxLayout.getShowDividerVertical(),
+                is(FlexboxLayout.SHOW_DIVIDER_BEGINNING | FlexboxLayout.SHOW_DIVIDER_MIDDLE |
+                        FlexboxLayout.SHOW_DIVIDER_END));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text4 = (TextView) activity.findViewById(R.id.text4);
+        Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider, null);
+        assertNotNull(divider);
+        int widthSum = text1.getWidth() + text4.getWidth() + divider.getIntrinsicWidth() * 3;
+        assertThat(text4.getRight() + divider.getIntrinsicWidth(), is(widthSum));
+        assertThat(text1.getLeft(), is(not(flexboxLayout.getLeft())));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionColumn_vertical_horizontal_All() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_column);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                Drawable divider = ResourcesCompat
+                        .getDrawable(activity.getResources(), R.drawable.divider, null);
+                flexboxLayout.setDividerDrawable(divider);
+                flexboxLayout.setShowDivider(
+                        FlexboxLayout.SHOW_DIVIDER_BEGINNING | FlexboxLayout.SHOW_DIVIDER_MIDDLE
+                                | FlexboxLayout.SHOW_DIVIDER_END);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+        assertThat(flexboxLayout.getShowDividerVertical(),
+                is(FlexboxLayout.SHOW_DIVIDER_BEGINNING | FlexboxLayout.SHOW_DIVIDER_MIDDLE |
+                        FlexboxLayout.SHOW_DIVIDER_END));
+        assertThat(flexboxLayout.getShowDividerHorizontal(),
+                is(FlexboxLayout.SHOW_DIVIDER_BEGINNING | FlexboxLayout.SHOW_DIVIDER_MIDDLE |
+                        FlexboxLayout.SHOW_DIVIDER_END));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text2 = (TextView) activity.findViewById(R.id.text2);
+        TextView text3 = (TextView) activity.findViewById(R.id.text3);
+        TextView text4 = (TextView) activity.findViewById(R.id.text4);
+        Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider, null);
+        assertNotNull(divider);
+        int heightSum = text1.getHeight() + text2.getHeight() + text3.getHeight()
+                + divider.getIntrinsicHeight() * 4;
+        int widthSum = text1.getWidth() + text4.getWidth() + divider.getIntrinsicWidth() * 3;
+        assertThat(text3.getBottom() + divider.getIntrinsicHeight(), is(heightSum));
+        assertThat(text4.getRight() + divider.getIntrinsicWidth(), is(widthSum));
+        assertThat(text1.getLeft(), is(not(flexboxLayout.getLeft())));
+        assertThat(text1.getTop(), is(not(flexboxLayout.getTop())));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
+    public void testDivider_directionColumn_all_thickDivider() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_divider_test_direction_column);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                Drawable thickDivider = ResourcesCompat
+                        .getDrawable(activity.getResources(), R.drawable.divider_thick, null);
+                flexboxLayout.setDividerDrawableHorizontal(thickDivider);
+                flexboxLayout.setShowDividerHorizontal(
+                        FlexboxLayout.SHOW_DIVIDER_BEGINNING | FlexboxLayout.SHOW_DIVIDER_MIDDLE
+                                | FlexboxLayout.SHOW_DIVIDER_END);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexWrap(), is(FlexboxLayout.FLEX_WRAP_WRAP));
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+        assertThat(flexboxLayout.getShowDividerHorizontal(),
+                is(FlexboxLayout.SHOW_DIVIDER_BEGINNING | FlexboxLayout.SHOW_DIVIDER_MIDDLE |
+                        FlexboxLayout.SHOW_DIVIDER_END));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text2 = (TextView) activity.findViewById(R.id.text2);
+        TextView text3 = (TextView) activity.findViewById(R.id.text3);
+        Drawable divider = ResourcesCompat
+                .getDrawable(activity.getResources(), R.drawable.divider_thick, null);
+        // The sum of three text views and the sum of thick dividers don't fit in one line.
+        // The last text view should be placed to the next line.
+        assertNotNull(divider);
+        int heightSum = text1.getHeight() + text2.getHeight()
+                + divider.getIntrinsicHeight() * 3;
+        assertThat(text2.getBottom() + divider.getIntrinsicHeight(), is(heightSum));
+        assertThat(text1.getTop(), is(not(flexboxLayout.getTop())));
+        assertThat(text3.getRight(), is(text1.getWidth() + text3.getWidth()));
+    }
+
     private TextView createTextView(Context context, String text, int order) {
         TextView textView = new TextView(context);
         textView.setText(text);
@@ -3136,7 +3803,7 @@ public class FlexboxAndroidTest {
     }
 
     private ViewAssertion hasWidth(final int width) {
-        return ViewAssertions.matches(new TypeSafeMatcher<View>() {
+        return matches(new TypeSafeMatcher<View>() {
             @Override
             public void describeTo(Description description) {
                 description.appendText("expected width: " + width);
@@ -3155,7 +3822,7 @@ public class FlexboxAndroidTest {
     }
 
     private ViewAssertion hasHeight(final int height) {
-        return ViewAssertions.matches(new TypeSafeMatcher<View>() {
+        return matches(new TypeSafeMatcher<View>() {
             @Override
             public void describeTo(Description description) {
                 description.appendText("expected height: " + height);

--- a/flexbox/src/androidTest/res/drawable/divider.xml
+++ b/flexbox/src/androidTest/res/drawable/divider.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" >
+    <size android:width="10dp" android:height="15dp"/>
+    <solid android:color="#44A444"/>
+</shape>

--- a/flexbox/src/androidTest/res/drawable/divider.xml
+++ b/flexbox/src/androidTest/res/drawable/divider.xml
@@ -1,5 +1,21 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android" >
-    <size android:width="10dp" android:height="15dp"/>
-    <solid android:color="#44A444"/>
+<?xml version="1.0" encoding="utf-8"?><!--
+Copyright 2016 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <size
+        android:width="10dp"
+        android:height="15dp" />
+    <solid android:color="#44A444" />
 </shape>

--- a/flexbox/src/androidTest/res/drawable/divider_thick.xml
+++ b/flexbox/src/androidTest/res/drawable/divider_thick.xml
@@ -1,5 +1,21 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android" >
-    <size android:width="40dp" android:height="42dp"/>
-    <solid android:color="#44A444"/>
+<?xml version="1.0" encoding="utf-8"?><!--
+Copyright 2016 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <size
+        android:width="40dp"
+        android:height="42dp" />
+    <solid android:color="#44A444" />
 </shape>

--- a/flexbox/src/androidTest/res/drawable/divider_thick.xml
+++ b/flexbox/src/androidTest/res/drawable/divider_thick.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" >
+    <size android:width="40dp" android:height="42dp"/>
+    <solid android:color="#44A444"/>
+</shape>

--- a/flexbox/src/androidTest/res/layout/activity_divider_test_direction_column.xml
+++ b/flexbox/src/androidTest/res/layout/activity_divider_test_direction_column.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2016 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="400dp"
+    android:layout_height="400dp"
+    app:flexDirection="column"
+    app:flexWrap="wrap"
+    app:alignContent="flex_start"
+    app:alignItems="flex_start"
+    app:dividerDrawableHorizontal="@drawable/divider"
+    app:showDividerHorizontal="beginning">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="80dp"
+        android:layout_height="90dp"
+        android:text="1" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="80dp"
+        android:layout_height="90dp"
+        android:text="2" />
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="80dp"
+        android:layout_height="90dp"
+        android:text="3" />
+
+    <TextView
+        android:id="@+id/text4"
+        android:layout_width="80dp"
+        android:layout_height="140dp"
+        android:text="4" />
+
+    <TextView
+        android:id="@+id/text5"
+        android:layout_width="80dp"
+        android:layout_height="140dp"
+        android:text="5" />
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/androidTest/res/layout/activity_divider_test_direction_row.xml
+++ b/flexbox/src/androidTest/res/layout/activity_divider_test_direction_row.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2016 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="400dp"
+    android:layout_height="400dp"
+    app:flexDirection="row"
+    app:flexWrap="wrap"
+    app:alignContent="flex_start"
+    app:alignItems="flex_start"
+    app:dividerDrawableVertical="@drawable/divider"
+    app:showDividerVertical="beginning">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="90dp"
+        android:layout_height="80dp"
+        android:text="1" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="90dp"
+        android:layout_height="80dp"
+        android:text="2" />
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="90dp"
+        android:layout_height="80dp"
+        android:text="3" />
+
+    <TextView
+        android:id="@+id/text4"
+        android:layout_width="140dp"
+        android:layout_height="80dp"
+        android:text="4" />
+
+    <TextView
+        android:id="@+id/text5"
+        android:layout_width="140dp"
+        android:layout_height="80dp"
+        android:text="5" />
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
@@ -219,6 +219,13 @@ public class FlexboxLayout extends ViewGroup {
      */
     private int mAlignContent;
 
+    /**
+     * The int definition to be used as the arguments for the {@link #setShowDivider(int)},
+     * {@link #setShowDividerHorizontal(int)} or {@link #setShowDividerVertical(int)}.
+     * One or more of the values (such as
+     * {@link #SHOW_DIVIDER_BEGINNING} | {@link #SHOW_DIVIDER_MIDDLE}) can be passed to those set
+     * methods.
+     */
     @IntDef(flag = true,
             value = {
                     SHOW_DIVIDER_NONE,
@@ -231,16 +238,22 @@ public class FlexboxLayout extends ViewGroup {
 
     }
 
+    /** Constant to how no dividers */
     public static final int SHOW_DIVIDER_NONE = 0;
 
+    /** Constant to show a divider at the beginning of the flex lines (or flex items). */
     public static final int SHOW_DIVIDER_BEGINNING = 1;
 
+    /** Constant to show dividers between flex lines or flex items. */
     public static final int SHOW_DIVIDER_MIDDLE = 1 << 1;
 
+    /** Constant to show a divider at the end of the flex lines or flex items. */
     public static final int SHOW_DIVIDER_END = 1 << 2;
 
+    /** The drawable to be drawn for the horizontal dividers. */
     private Drawable mDividerDrawableHorizontal;
 
+    /** The drawable to be drawn for the vertical dividers. */
     private Drawable mDividerDrawableVertical;
 
     /**
@@ -257,8 +270,10 @@ public class FlexboxLayout extends ViewGroup {
      */
     private int mShowDividerVertical;
 
+    /** The height of the {@link #mDividerDrawableHorizontal}. */
     private int mDividerHorizontalHeight;
 
+    /** The width of the {@link #mDividerDrawableVertical}. */
     private int mDividerVerticalWidth;
 
     /**
@@ -1172,7 +1187,7 @@ public class FlexboxLayout extends ViewGroup {
                     case ALIGN_CONTENT_STRETCH: {
                         float freeSpaceUnit = (size - totalCrossSize) / (float) mFlexLines.size();
                         float accumulatedError = 0;
-                        for (int i = 0; i < mFlexLines.size(); i++) {
+                        for (int i = 0, flexLinesSize = mFlexLines.size(); i < flexLinesSize; i++) {
                             FlexLine flexLine = mFlexLines.get(i);
                             float newCrossSizeAsFloat = flexLine.crossSize + freeSpaceUnit;
                             if (i == mFlexLines.size() - 1) {
@@ -1217,7 +1232,7 @@ public class FlexboxLayout extends ViewGroup {
                         spaceBetweenFlexLine = spaceBetweenFlexLine / (float) numberOfSpaces;
                         float accumulatedError = 0;
                         List<FlexLine> newFlexLines = new ArrayList<>();
-                        for (int i = 0; i < mFlexLines.size(); i++) {
+                        for (int i = 0, flexLineSize = mFlexLines.size(); i < flexLineSize; i++) {
                             FlexLine flexLine = mFlexLines.get(i);
                             newFlexLines.add(flexLine);
 
@@ -1253,7 +1268,7 @@ public class FlexboxLayout extends ViewGroup {
                         List<FlexLine> newFlexLines = new ArrayList<>();
                         FlexLine dummySpaceFlexLine = new FlexLine();
                         dummySpaceFlexLine.crossSize = spaceAboveAndBottom;
-                        for (int i = 0; i < mFlexLines.size(); i++) {
+                        for (int i = 0, flexLineSize = mFlexLines.size(); i < flexLineSize; i++) {
                             if (i == 0) {
                                 newFlexLines.add(dummySpaceFlexLine);
                             }
@@ -1487,6 +1502,9 @@ public class FlexboxLayout extends ViewGroup {
         if (lp.wrapBefore) {
             return true;
         }
+        if (mode == MeasureSpec.UNSPECIFIED) {
+            return false;
+        }
         if (isMainAxisDirectionHorizontal(mFlexDirection)) {
             if (hasDividerBeforeChildAtAlongMainAxis(childAbsoluteIndex,
                     childRelativeIndexInFlexLine)) {
@@ -1504,8 +1522,7 @@ public class FlexboxLayout extends ViewGroup {
                 childLength += mDividerHorizontalHeight;
             }
         }
-        return (mode == MeasureSpec.EXACTLY || mode == MeasureSpec.AT_MOST) &&
-                maxSize < currentLength + childLength;
+        return maxSize < currentLength + childLength;
     }
 
     /**
@@ -1528,10 +1545,10 @@ public class FlexboxLayout extends ViewGroup {
      */
     private int getSumOfCrossSize() {
         int sum = 0;
-        for (int i = 0; i < mFlexLines.size(); i++) {
+        for (int i = 0, size = mFlexLines.size(); i < size; i++) {
             FlexLine flexLine = mFlexLines.get(i);
 
-            // Judge if the beginning divider is required
+            // Judge if the beginning or middle dividers are required
             if (hasDividerBeforeFlexLine(i)) {
                 if (isMainAxisDirectionHorizontal(mFlexDirection)) {
                     sum += mDividerHorizontalHeight;
@@ -1628,7 +1645,7 @@ public class FlexboxLayout extends ViewGroup {
         // Use float to reduce the round error that may happen in when justifyContent ==
         // SPACE_BETWEEN or SPACE_AROUND
         float childRight;
-        for (int i = 0; i < mFlexLines.size(); i++) {
+        for (int i = 0, size = mFlexLines.size(); i < size; i++) {
             FlexLine flexLine = mFlexLines.get(i);
             if (hasDividerBeforeFlexLine(i)) {
                 childBottom -= mDividerHorizontalHeight;
@@ -1844,7 +1861,7 @@ public class FlexboxLayout extends ViewGroup {
         // Used only for if the direction is from bottom to top
         float childBottom;
 
-        for (int i = 0; i < mFlexLines.size(); i++) {
+        for (int i = 0, size = mFlexLines.size(); i < size; i++) {
             FlexLine flexLine = mFlexLines.get(i);
             if (hasDividerBeforeFlexLine(i)) {
                 childLeft += mDividerVerticalWidth;
@@ -2069,7 +2086,7 @@ public class FlexboxLayout extends ViewGroup {
         int paddingLeft = getPaddingLeft();
         int paddingRight = getPaddingRight();
         int horizontalDividerLength = Math.max(0, getWidth() - paddingRight - paddingLeft);
-        for (int i = 0; i < mFlexLines.size(); i++) {
+        for (int i = 0, size = mFlexLines.size(); i < size; i++) {
             FlexLine flexLine = mFlexLines.get(i);
             for (int j = 0; j < flexLine.itemCount; j++) {
                 View view = getReorderedChildAt(currentViewIndex);
@@ -2146,7 +2163,7 @@ public class FlexboxLayout extends ViewGroup {
         int paddingTop = getPaddingTop();
         int paddingBottom = getPaddingBottom();
         int verticalDividerLength = Math.max(0, getHeight() - paddingBottom - paddingTop);
-        for (int i = 0; i < mFlexLines.size(); i++) {
+        for (int i = 0, size = mFlexLines.size(); i < size; i++) {
             FlexLine flexLine = mFlexLines.get(i);
 
             // Draw horizontal dividers if needed

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
@@ -18,6 +18,8 @@ package com.google.android.flexbox;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
 import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.v4.view.ViewCompat;
@@ -48,6 +50,12 @@ import java.util.List;
  * <li>{@code justifyContent}</li>
  * <li>{@code alignItems}</li>
  * <li>{@code alignContent}</li>
+ * <li>{@code showDivider}</li>
+ * <li>{@code showDividerHorizontal}</li>
+ * <li>{@code showDividerVertical}</li>
+ * <li>{@code dividerDrawable}</li>
+ * <li>{@code dividerDrawableHorizontal}</li>
+ * <li>{@code dividerDrawableVertical}</li>
  * </ul>
  * for the FlexboxLayout.
  *
@@ -211,6 +219,48 @@ public class FlexboxLayout extends ViewGroup {
      */
     private int mAlignContent;
 
+    @IntDef(flag = true,
+            value = {
+                    SHOW_DIVIDER_NONE,
+                    SHOW_DIVIDER_BEGINNING,
+                    SHOW_DIVIDER_MIDDLE,
+                    SHOW_DIVIDER_END
+            })
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface DividerMode {
+
+    }
+
+    public static final int SHOW_DIVIDER_NONE = 0;
+
+    public static final int SHOW_DIVIDER_BEGINNING = 1;
+
+    public static final int SHOW_DIVIDER_MIDDLE = 1 << 1;
+
+    public static final int SHOW_DIVIDER_END = 1 << 2;
+
+    private Drawable mDividerDrawableHorizontal;
+
+    private Drawable mDividerDrawableVertical;
+
+    /**
+     * Indicates the divider mode for the {@link #mDividerDrawableHorizontal}. The value needs to
+     * be the combination of the value of {@link #SHOW_DIVIDER_NONE},
+     * {@link #SHOW_DIVIDER_BEGINNING}, {@link #SHOW_DIVIDER_MIDDLE} and {@link #SHOW_DIVIDER_END}
+     */
+    private int mShowDividerHorizontal;
+
+    /**
+     * Indicates the divider mode for the {@link #mDividerDrawableVertical}. The value needs to
+     * be the combination of the value of {@link #SHOW_DIVIDER_NONE},
+     * {@link #SHOW_DIVIDER_BEGINNING}, {@link #SHOW_DIVIDER_MIDDLE} and {@link #SHOW_DIVIDER_END}
+     */
+    private int mShowDividerVertical;
+
+    private int mDividerHorizontalHeight;
+
+    private int mDividerVerticalWidth;
+
     /**
      * Holds reordered indices, which {@link LayoutParams#order} parameters are taken into account
      */
@@ -251,6 +301,36 @@ public class FlexboxLayout extends ViewGroup {
                 .getInt(R.styleable.FlexboxLayout_justifyContent, JUSTIFY_CONTENT_FLEX_START);
         mAlignItems = a.getInt(R.styleable.FlexboxLayout_alignItems, ALIGN_ITEMS_STRETCH);
         mAlignContent = a.getInt(R.styleable.FlexboxLayout_alignContent, ALIGN_CONTENT_STRETCH);
+        Drawable drawable = a.getDrawable(R.styleable.FlexboxLayout_dividerDrawable);
+        if (drawable != null) {
+            setDividerDrawableHorizontal(drawable);
+            setDividerDrawableVertical(drawable);
+        }
+        Drawable drawableHorizontal = a
+                .getDrawable(R.styleable.FlexboxLayout_dividerDrawableHorizontal);
+        if (drawableHorizontal != null) {
+            setDividerDrawableHorizontal(drawableHorizontal);
+        }
+        Drawable drawableVertical = a
+                .getDrawable(R.styleable.FlexboxLayout_dividerDrawableVertical);
+        if (drawableVertical != null) {
+            setDividerDrawableVertical(drawableVertical);
+        }
+        int dividerMode = a.getInt(R.styleable.FlexboxLayout_showDivider, SHOW_DIVIDER_NONE);
+        if (dividerMode != SHOW_DIVIDER_NONE) {
+            mShowDividerVertical = dividerMode;
+            mShowDividerHorizontal = dividerMode;
+        }
+        int dividerModeVertical = a
+                .getInt(R.styleable.FlexboxLayout_showDividerVertical, SHOW_DIVIDER_NONE);
+        if (dividerModeVertical != SHOW_DIVIDER_NONE) {
+            mShowDividerVertical = dividerModeVertical;
+        }
+        int dividerModeHorizontal = a
+                .getInt(R.styleable.FlexboxLayout_showDividerHorizontal, SHOW_DIVIDER_NONE);
+        if (dividerModeHorizontal != SHOW_DIVIDER_NONE) {
+            mShowDividerHorizontal = dividerModeHorizontal;
+        }
         a.recycle();
     }
 
@@ -448,6 +528,9 @@ public class FlexboxLayout extends ViewGroup {
             int paddingEnd = ViewCompat.getPaddingEnd(this);
             int largestHeightInRow = Integer.MIN_VALUE;
             FlexLine flexLine = new FlexLine();
+
+            // The index of the view in a same flex line.
+            int indexInFlexLine = 0;
             flexLine.mainSize = paddingStart + paddingEnd;
             for (int i = 0; i < childCount; i++) {
                 View child = getReorderedChildAt(i);
@@ -497,27 +580,35 @@ public class FlexboxLayout extends ViewGroup {
                 largestHeightInRow = Math.max(largestHeightInRow,
                         child.getMeasuredHeight() + lp.topMargin + lp.bottomMargin);
 
-                if (isWrapRequired(mFlexWrap, widthMode, widthSize, flexLine.mainSize,
-                        child.getMeasuredWidth() + lp.leftMargin + lp.rightMargin, lp)) {
+                if (isWrapRequired(widthMode, widthSize, flexLine.mainSize,
+                        child.getMeasuredWidth() + lp.leftMargin + lp.rightMargin, lp,
+                        i, indexInFlexLine)) {
                     if (flexLine.itemCount > 0) {
-                        mFlexLines.add(flexLine);
+                        addFlexLine(flexLine);
                     }
 
                     flexLine = new FlexLine();
                     flexLine.itemCount = 1;
                     flexLine.mainSize = paddingStart + paddingEnd;
                     largestHeightInRow = child.getMeasuredHeight() + lp.topMargin + lp.bottomMargin;
+                    indexInFlexLine = 0;
                 } else {
                     flexLine.itemCount++;
+                    indexInFlexLine++;
                 }
-                flexLine.mainSize += child.getMeasuredWidth() + lp.leftMargin
-                        + lp.rightMargin;
+                flexLine.mainSize += child.getMeasuredWidth() + lp.leftMargin + lp.rightMargin;
                 flexLine.totalFlexGrow += lp.flexGrow;
                 flexLine.totalFlexShrink += lp.flexShrink;
                 // Temporarily set the cross axis length as the largest child in the row
                 // Expand along the cross axis depending on the mAlignContent property if needed
                 // later
                 flexLine.crossSize = Math.max(flexLine.crossSize, largestHeightInRow);
+
+                // Check if the beginning or middle divider is required for the flex item
+                if (hasDividerBeforeChildAtAlongMainAxis(i, indexInFlexLine)) {
+                    flexLine.mainSize += mDividerVerticalWidth;
+                    flexLine.dividerLengthInMainSize += mDividerVerticalWidth;
+                }
 
                 if (mFlexWrap != FLEX_WRAP_WRAP_REVERSE) {
                     flexLine.maxBaseline = Math
@@ -573,7 +664,6 @@ public class FlexboxLayout extends ViewGroup {
                 childState);
     }
 
-
     /**
      * Sub method for {@link #onMeasure(int, int)} when the main axis direction is vertical
      * (either from top to bottom or bottom to top).
@@ -602,6 +692,8 @@ public class FlexboxLayout extends ViewGroup {
         int largestWidthInColumn = Integer.MIN_VALUE;
         FlexLine flexLine = new FlexLine();
         flexLine.mainSize = paddingTop + paddingBottom;
+        // The index of the view in a same flex line.
+        int indexInFlexLine = 0;
         for (int i = 0; i < childCount; i++) {
             View child = getReorderedChildAt(i);
             if (child == null) {
@@ -650,19 +742,21 @@ public class FlexboxLayout extends ViewGroup {
             largestWidthInColumn = Math.max(largestWidthInColumn,
                     child.getMeasuredWidth() + lp.leftMargin + lp.rightMargin);
 
-            if (isWrapRequired(mFlexWrap, heightMode, heightSize, flexLine.mainSize,
-                    child.getMeasuredHeight() + lp.topMargin + lp.bottomMargin, lp)) {
+            if (isWrapRequired(heightMode, heightSize, flexLine.mainSize,
+                    child.getMeasuredHeight() + lp.topMargin + lp.bottomMargin, lp,
+                    i, indexInFlexLine)) {
                 if (flexLine.itemCount > 0) {
-                    mFlexLines.add(flexLine);
+                    addFlexLine(flexLine);
                 }
 
                 flexLine = new FlexLine();
                 flexLine.itemCount = 1;
                 flexLine.mainSize = paddingTop + paddingBottom;
-                largestWidthInColumn = child.getMeasuredWidth() + lp.leftMargin
-                        + lp.rightMargin;
+                largestWidthInColumn = child.getMeasuredWidth() + lp.leftMargin + lp.rightMargin;
+                indexInFlexLine = 0;
             } else {
                 flexLine.itemCount++;
+                indexInFlexLine++;
             }
             flexLine.mainSize += child.getMeasuredHeight() + lp.topMargin + lp.bottomMargin;
             flexLine.totalFlexGrow += lp.flexGrow;
@@ -672,6 +766,9 @@ public class FlexboxLayout extends ViewGroup {
             // later
             flexLine.crossSize = Math.max(flexLine.crossSize, largestWidthInColumn);
 
+            if (hasDividerBeforeChildAtAlongMainAxis(i, indexInFlexLine)) {
+                flexLine.mainSize += mDividerHorizontalHeight;
+            }
             addFlexLineIfLastFlexItem(i, childCount, flexLine);
         }
 
@@ -722,8 +819,25 @@ public class FlexboxLayout extends ViewGroup {
     private void addFlexLineIfLastFlexItem(int childIndex, int childCount, FlexLine flexLine) {
         if (childIndex == childCount - 1 && flexLine.itemCount != 0) {
             // Add the flex line if this item is the last item
-            mFlexLines.add(flexLine);
+            addFlexLine(flexLine);
         }
+    }
+
+    private void addFlexLine(FlexLine flexLine) {
+        // The size of the end divider isn't added until the flexLine is added to the flex container
+        // take the divider width (or height) into account when adding the flex line.
+        if (isMainAxisDirectionHorizontal(mFlexDirection)) {
+            if ((mShowDividerVertical & SHOW_DIVIDER_END) > 0) {
+                flexLine.mainSize += mDividerVerticalWidth;
+                flexLine.dividerLengthInMainSize += mDividerVerticalWidth;
+            }
+        } else {
+            if ((mShowDividerHorizontal & SHOW_DIVIDER_END) > 0) {
+                flexLine.mainSize += mDividerHorizontalHeight;
+                flexLine.dividerLengthInMainSize += mDividerHorizontalHeight;
+            }
+        }
+        mFlexLines.add(flexLine);
     }
 
     /**
@@ -806,7 +920,7 @@ public class FlexboxLayout extends ViewGroup {
         int sizeBeforeExpand = flexLine.mainSize;
         boolean needsReexpand = false;
         float unitSpace = (maxMainSize - flexLine.mainSize) / flexLine.totalFlexGrow;
-        flexLine.mainSize = paddingAlongMainAxis;
+        flexLine.mainSize = paddingAlongMainAxis + flexLine.dividerLengthInMainSize;
         float accumulatedRoundError = 0;
         for (int i = 0; i < flexLine.itemCount; i++) {
             View child = getReorderedChildAt(childIndex);
@@ -817,8 +931,7 @@ public class FlexboxLayout extends ViewGroup {
                 continue;
             }
             LayoutParams lp = (LayoutParams) child.getLayoutParams();
-            if (flexDirection == FLEX_DIRECTION_ROW
-                    || flexDirection == FLEX_DIRECTION_ROW_REVERSE) {
+            if (isMainAxisDirectionHorizontal(flexDirection)) {
                 // The direction of the main axis is horizontal
                 if (!mChildrenFrozen[childIndex]) {
                     float rawCalculatedWidth = child.getMeasuredWidth() + unitSpace * lp.flexGrow;
@@ -927,7 +1040,7 @@ public class FlexboxLayout extends ViewGroup {
         boolean needsReshrink = false;
         float unitShrink = (flexLine.mainSize - maxMainSize) / flexLine.totalFlexShrink;
         float accumulatedRoundError = 0;
-        flexLine.mainSize = paddingAlongMainAxis;
+        flexLine.mainSize = paddingAlongMainAxis + flexLine.dividerLengthInMainSize;
         for (int i = 0; i < flexLine.itemCount; i++) {
             View child = getReorderedChildAt(childIndex);
             if (child == null) {
@@ -937,8 +1050,7 @@ public class FlexboxLayout extends ViewGroup {
                 continue;
             }
             LayoutParams lp = (LayoutParams) child.getLayoutParams();
-            if (flexDirection == FLEX_DIRECTION_ROW
-                    || flexDirection == FLEX_DIRECTION_ROW_REVERSE) {
+            if (isMainAxisDirectionHorizontal(flexDirection)) {
                 // The direction of main axis is horizontal
                 if (!mChildrenFrozen[childIndex]) {
                     float rawCalculatedWidth = child.getMeasuredWidth()
@@ -1278,7 +1390,8 @@ public class FlexboxLayout extends ViewGroup {
         switch (flexDirection) {
             case FLEX_DIRECTION_ROW: // Intentional fall through
             case FLEX_DIRECTION_ROW_REVERSE:
-                calculatedMaxHeight = getSumOfCrossSize() + getPaddingTop() + getPaddingBottom();
+                calculatedMaxHeight = getSumOfCrossSize() + getPaddingTop()
+                        + getPaddingBottom();
                 calculatedMaxWidth = getLargestMainSize();
                 break;
             case FLEX_DIRECTION_COLUMN: // Intentional fall through
@@ -1356,7 +1469,6 @@ public class FlexboxLayout extends ViewGroup {
     /**
      * Determine if a wrap is required (add a new flex line).
      *
-     * @param flexWrap      the flexWrap attribute
      * @param mode          the width or height mode along the main axis direction
      * @param maxSize       the max size along the main axis direction
      * @param currentLength the accumulated current length
@@ -1367,13 +1479,30 @@ public class FlexboxLayout extends ViewGroup {
      * @see #getFlexWrap()
      * @see #setFlexWrap(int)
      */
-    private boolean isWrapRequired(int flexWrap, int mode, int maxSize,
-            int currentLength, int childLength, LayoutParams lp) {
-        if (flexWrap == FLEX_WRAP_NOWRAP) {
+    private boolean isWrapRequired(int mode, int maxSize, int currentLength, int childLength,
+            LayoutParams lp, int childAbsoluteIndex, int childRelativeIndexInFlexLine) {
+        if (mFlexWrap == FLEX_WRAP_NOWRAP) {
             return false;
         }
         if (lp.wrapBefore) {
             return true;
+        }
+        if (isMainAxisDirectionHorizontal(mFlexDirection)) {
+            if (hasDividerBeforeChildAtAlongMainAxis(childAbsoluteIndex,
+                    childRelativeIndexInFlexLine)) {
+                childLength += mDividerVerticalWidth;
+            }
+            if ((mShowDividerVertical & SHOW_DIVIDER_END) > 0) {
+                childLength += mDividerVerticalWidth;
+            }
+        } else {
+            if (hasDividerBeforeChildAtAlongMainAxis(childAbsoluteIndex,
+                    childRelativeIndexInFlexLine)) {
+                childLength += mDividerHorizontalHeight;
+            }
+            if ((mShowDividerHorizontal & SHOW_DIVIDER_END) > 0) {
+                childLength += mDividerHorizontalHeight;
+            }
         }
         return (mode == MeasureSpec.EXACTLY || mode == MeasureSpec.AT_MOST) &&
                 maxSize < currentLength + childLength;
@@ -1393,16 +1522,40 @@ public class FlexboxLayout extends ViewGroup {
     }
 
     /**
-     * Retrieve the sum of the cross sizes of all flex lines.
+     * Retrieve the sum of the cross sizes of all flex lines including divider lengths.
      *
      * @return the sum of the cross sizes
      */
     private int getSumOfCrossSize() {
         int sum = 0;
-        for (FlexLine flexLine : mFlexLines) {
+        for (int i = 0; i < mFlexLines.size(); i++) {
+            FlexLine flexLine = mFlexLines.get(i);
+
+            // Judge if the beginning divider is required
+            if (hasDividerBeforeFlexLine(i)) {
+                if (isMainAxisDirectionHorizontal(mFlexDirection)) {
+                    sum += mDividerHorizontalHeight;
+                } else {
+                    sum += mDividerVerticalWidth;
+                }
+            }
+
+            // Judge if the end divider is required
+            if (hasEndDividerAfterFlexLine(i)) {
+                if (isMainAxisDirectionHorizontal(mFlexDirection)) {
+                    sum += mDividerHorizontalHeight;
+                } else {
+                    sum += mDividerVerticalWidth;
+                }
+            }
             sum += flexLine.crossSize;
         }
         return sum;
+    }
+
+    private boolean isMainAxisDirectionHorizontal(@FlexDirection int flexDirection) {
+        return flexDirection == FLEX_DIRECTION_ROW
+                || flexDirection == FLEX_DIRECTION_ROW_REVERSE;
     }
 
     @Override
@@ -1475,7 +1628,12 @@ public class FlexboxLayout extends ViewGroup {
         // Use float to reduce the round error that may happen in when justifyContent ==
         // SPACE_BETWEEN or SPACE_AROUND
         float childRight;
-        for (FlexLine flexLine : mFlexLines) {
+        for (int i = 0; i < mFlexLines.size(); i++) {
+            FlexLine flexLine = mFlexLines.get(i);
+            if (hasDividerBeforeFlexLine(i)) {
+                childBottom -= mDividerHorizontalHeight;
+                childTop += mDividerHorizontalHeight;
+            }
             float spaceBetweenItem = 0f;
             switch (mJustifyContent) {
                 case JUSTIFY_CONTENT_FLEX_START:
@@ -1509,7 +1667,7 @@ public class FlexboxLayout extends ViewGroup {
             }
             spaceBetweenItem = Math.max(spaceBetweenItem, 0);
 
-            for (int i = 0; i < flexLine.itemCount; i++) {
+            for (int j = 0; j < flexLine.itemCount; j++) {
                 View child = getReorderedChildAt(currentViewIndex);
                 if (child == null) {
                     continue;
@@ -1520,6 +1678,11 @@ public class FlexboxLayout extends ViewGroup {
                 LayoutParams lp = ((LayoutParams) child.getLayoutParams());
                 childLeft += lp.leftMargin;
                 childRight -= lp.rightMargin;
+                if (hasDividerBeforeChildAtAlongMainAxis(currentViewIndex, j)) {
+                    childLeft += mDividerVerticalWidth;
+                    childRight -= mDividerVerticalWidth;
+                }
+
                 if (mFlexWrap == FLEX_WRAP_WRAP_REVERSE) {
                     if (isRtl) {
                         layoutSingleChildHorizontal(child, flexLine, mFlexWrap, mAlignItems,
@@ -1547,6 +1710,11 @@ public class FlexboxLayout extends ViewGroup {
                 childLeft += child.getMeasuredWidth() + spaceBetweenItem + lp.rightMargin;
                 childRight -= child.getMeasuredWidth() + spaceBetweenItem + lp.leftMargin;
                 currentViewIndex++;
+
+                flexLine.left = Math.min(flexLine.left, child.getLeft() - lp.leftMargin);
+                flexLine.top = Math.min(flexLine.top, child.getTop() - lp.topMargin);
+                flexLine.right = Math.max(flexLine.right, child.getRight() + lp.rightMargin);
+                flexLine.bottom = Math.max(flexLine.bottom, child.getBottom() + lp.bottomMargin);
             }
             childTop += flexLine.crossSize;
             childBottom -= flexLine.crossSize;
@@ -1675,7 +1843,13 @@ public class FlexboxLayout extends ViewGroup {
 
         // Used only for if the direction is from bottom to top
         float childBottom;
-        for (FlexLine flexLine : mFlexLines) {
+
+        for (int i = 0; i < mFlexLines.size(); i++) {
+            FlexLine flexLine = mFlexLines.get(i);
+            if (hasDividerBeforeFlexLine(i)) {
+                childLeft += mDividerVerticalWidth;
+                childRight -= mDividerVerticalWidth;
+            }
             float spaceBetweenItem = 0f;
             switch (mJustifyContent) {
                 case JUSTIFY_CONTENT_FLEX_START:
@@ -1710,7 +1884,7 @@ public class FlexboxLayout extends ViewGroup {
             }
             spaceBetweenItem = Math.max(spaceBetweenItem, 0);
 
-            for (int i = 0; i < flexLine.itemCount; i++) {
+            for (int j = 0; j < flexLine.itemCount; j++) {
                 View child = getReorderedChildAt(currentViewIndex);
                 if (child == null) {
                     continue;
@@ -1721,6 +1895,10 @@ public class FlexboxLayout extends ViewGroup {
                 LayoutParams lp = ((LayoutParams) child.getLayoutParams());
                 childTop += lp.topMargin;
                 childBottom -= lp.bottomMargin;
+                if (hasDividerBeforeChildAtAlongMainAxis(currentViewIndex, j)) {
+                    childTop += mDividerHorizontalHeight;
+                    childBottom -= mDividerHorizontalHeight;
+                }
                 if (isRtl) {
                     if (fromBottomToTop) {
                         layoutSingleChildVertical(child, flexLine, true, mAlignItems,
@@ -1747,6 +1925,11 @@ public class FlexboxLayout extends ViewGroup {
                 childTop += child.getMeasuredHeight() + spaceBetweenItem + lp.bottomMargin;
                 childBottom -= child.getMeasuredHeight() + spaceBetweenItem + lp.topMargin;
                 currentViewIndex++;
+
+                flexLine.left = Math.min(flexLine.left, child.getLeft() - lp.leftMargin);
+                flexLine.top = Math.min(flexLine.top, child.getTop() - lp.topMargin);
+                flexLine.right = Math.max(flexLine.right, child.getRight() + lp.rightMargin);
+                flexLine.bottom = Math.max(flexLine.bottom, child.getBottom() + lp.bottomMargin);
             }
             childLeft += flexLine.crossSize;
             childRight -= flexLine.crossSize;
@@ -1824,6 +2007,226 @@ public class FlexboxLayout extends ViewGroup {
     }
 
     @Override
+    protected void onDraw(Canvas canvas) {
+        if (mDividerDrawableVertical == null && mDividerDrawableHorizontal == null) {
+            return;
+        }
+        if (mShowDividerHorizontal == SHOW_DIVIDER_NONE
+                && mShowDividerVertical == SHOW_DIVIDER_NONE) {
+            return;
+        }
+
+        int layoutDirection = ViewCompat.getLayoutDirection(this);
+        boolean isRtl;
+        boolean fromBottomToTop = false;
+        switch (mFlexDirection) {
+            case FLEX_DIRECTION_ROW:
+                isRtl = layoutDirection == ViewCompat.LAYOUT_DIRECTION_RTL;
+                if (mFlexWrap == FLEX_WRAP_WRAP_REVERSE) {
+                    fromBottomToTop = true;
+                }
+                drawDividersHorizontal(canvas, isRtl, fromBottomToTop);
+                break;
+            case FLEX_DIRECTION_ROW_REVERSE:
+                isRtl = layoutDirection != ViewCompat.LAYOUT_DIRECTION_RTL;
+                if (mFlexWrap == FLEX_WRAP_WRAP_REVERSE) {
+                    fromBottomToTop = true;
+                }
+                drawDividersHorizontal(canvas, isRtl, fromBottomToTop);
+                break;
+            case FLEX_DIRECTION_COLUMN:
+                isRtl = layoutDirection == ViewCompat.LAYOUT_DIRECTION_RTL;
+                if (mFlexWrap == FLEX_WRAP_WRAP_REVERSE) {
+                    isRtl = !isRtl;
+                }
+                fromBottomToTop = false;
+                drawDividersVertical(canvas, isRtl, fromBottomToTop);
+                break;
+            case FLEX_DIRECTION_COLUMN_REVERSE:
+                isRtl = layoutDirection == ViewCompat.LAYOUT_DIRECTION_RTL;
+                if (mFlexWrap == FLEX_WRAP_WRAP_REVERSE) {
+                    isRtl = !isRtl;
+                }
+                fromBottomToTop = true;
+                drawDividersVertical(canvas, isRtl, fromBottomToTop);
+                break;
+        }
+    }
+
+    /**
+     * Sub method for {@link #onDraw(Canvas)} when the main axis direction is horizontal
+     * ({@link #mFlexDirection} is either of {@link #FLEX_DIRECTION_ROW} or
+     * {@link #FLEX_DIRECTION_ROW_REVERSE}.
+     *
+     * @param canvas          the canvas on which the background will be drawn
+     * @param isRtl           {@code true} when the horizontal layout direction is right to left,
+     *                        {@code false} otherwise
+     * @param fromBottomToTop {@code true} when the vertical layout direction is bottom to top,
+     *                        {@code false} otherwise
+     */
+    private void drawDividersHorizontal(Canvas canvas, boolean isRtl, boolean fromBottomToTop) {
+        int currentViewIndex = 0;
+        int paddingLeft = getPaddingLeft();
+        int paddingRight = getPaddingRight();
+        int horizontalDividerLength = Math.max(0, getWidth() - paddingRight - paddingLeft);
+        for (int i = 0; i < mFlexLines.size(); i++) {
+            FlexLine flexLine = mFlexLines.get(i);
+            for (int j = 0; j < flexLine.itemCount; j++) {
+                View view = getReorderedChildAt(currentViewIndex);
+                LayoutParams lp = (LayoutParams) view.getLayoutParams();
+
+                // Judge if the beginning or middle divider is needed
+                if (hasDividerBeforeChildAtAlongMainAxis(currentViewIndex, j)) {
+                    int dividerLeft;
+                    if (isRtl) {
+                        dividerLeft = view.getRight() + lp.rightMargin;
+                    } else {
+                        dividerLeft = view.getLeft() - lp.leftMargin - mDividerVerticalWidth;
+                    }
+
+                    drawVerticalDivider(canvas, dividerLeft, flexLine.top, flexLine.crossSize);
+                }
+
+                // Judge if the end divider is needed
+                if (j == flexLine.itemCount - 1) {
+                    if ((mShowDividerVertical & SHOW_DIVIDER_END) > 0) {
+                        int dividerLeft;
+                        if (isRtl) {
+                            dividerLeft = view.getLeft() - lp.leftMargin - mDividerVerticalWidth;
+                        } else {
+                            dividerLeft = view.getRight() + lp.rightMargin;
+                        }
+
+                        drawVerticalDivider(canvas, dividerLeft, flexLine.top, flexLine.crossSize);
+                    }
+                }
+                currentViewIndex++;
+            }
+
+            // Judge if the beginning or middle dividers are needed before the flex line
+            if (hasDividerBeforeFlexLine(i)) {
+                int horizontalDividerTop;
+                if (fromBottomToTop) {
+                    horizontalDividerTop = flexLine.bottom;
+                } else {
+                    horizontalDividerTop = flexLine.top - mDividerHorizontalHeight;
+                }
+                drawHorizontalDivider(canvas, paddingLeft, horizontalDividerTop,
+                        horizontalDividerLength);
+            }
+            // Judge if the end divider is needed before the flex line
+            if (hasEndDividerAfterFlexLine(i)) {
+                if ((mShowDividerHorizontal & SHOW_DIVIDER_END) > 0) {
+                    int horizontalDividerTop;
+                    if (fromBottomToTop) {
+                        horizontalDividerTop = flexLine.top - mDividerHorizontalHeight;
+                    } else {
+                        horizontalDividerTop = flexLine.bottom;
+                    }
+                    drawHorizontalDivider(canvas, paddingLeft, horizontalDividerTop,
+                            horizontalDividerLength);
+                }
+            }
+        }
+    }
+
+    /**
+     * Sub method for {@link #onDraw(Canvas)} when the main axis direction is vertical
+     * ({@link #mFlexDirection} is either of {@link #FLEX_DIRECTION_COLUMN} or
+     * {@link #FLEX_DIRECTION_COLUMN_REVERSE}.
+     *
+     * @param canvas          the canvas on which the background will be drawn
+     * @param isRtl           {@code true} when the horizontal layout direction is right to left,
+     *                        {@code false} otherwise
+     * @param fromBottomToTop {@code true} when the vertical layout direction is bottom to top,
+     *                        {@code false} otherwise
+     */
+    private void drawDividersVertical(Canvas canvas, boolean isRtl, boolean fromBottomToTop) {
+        int currentViewIndex = 0;
+        int paddingTop = getPaddingTop();
+        int paddingBottom = getPaddingBottom();
+        int verticalDividerLength = Math.max(0, getHeight() - paddingBottom - paddingTop);
+        for (int i = 0; i < mFlexLines.size(); i++) {
+            FlexLine flexLine = mFlexLines.get(i);
+
+            // Draw horizontal dividers if needed
+            for (int j = 0; j < flexLine.itemCount; j++) {
+                View view = getReorderedChildAt(currentViewIndex);
+                LayoutParams lp = (LayoutParams) view.getLayoutParams();
+
+                // Judge if the beginning or middle divider is needed
+                if (hasDividerBeforeChildAtAlongMainAxis(currentViewIndex, j)) {
+                    int dividerTop;
+                    if (fromBottomToTop) {
+                        dividerTop = view.getBottom() + lp.bottomMargin;
+                    } else {
+                        dividerTop = view.getTop() - lp.topMargin - mDividerHorizontalHeight;
+                    }
+
+                    drawHorizontalDivider(canvas, flexLine.left, dividerTop, flexLine.crossSize);
+                }
+
+                // Judge if the end divider is needed
+                if (j == flexLine.itemCount - 1) {
+                    if ((mShowDividerHorizontal & SHOW_DIVIDER_END) > 0) {
+                        int dividerTop;
+                        if (fromBottomToTop) {
+                            dividerTop = view.getTop() - lp.topMargin - mDividerHorizontalHeight;
+                        } else {
+                            dividerTop = view.getBottom() + lp.bottomMargin;
+                        }
+
+                        drawHorizontalDivider(canvas, flexLine.left, dividerTop,
+                                flexLine.crossSize);
+                    }
+                }
+                currentViewIndex++;
+            }
+
+            // Judge if the beginning or middle dividers are needed before the flex line
+            if (hasDividerBeforeFlexLine(i)) {
+                int verticalDividerLeft;
+                if (isRtl) {
+                    verticalDividerLeft = flexLine.right;
+                } else {
+                    verticalDividerLeft = flexLine.left - mDividerVerticalWidth;
+                }
+                drawVerticalDivider(canvas, verticalDividerLeft, paddingTop,
+                        verticalDividerLength);
+            }
+            if (hasEndDividerAfterFlexLine(i)) {
+                if ((mShowDividerVertical & SHOW_DIVIDER_END) > 0) {
+                    int verticalDividerLeft;
+                    if (isRtl) {
+                        verticalDividerLeft = flexLine.left - mDividerVerticalWidth;
+                    } else {
+                        verticalDividerLeft = flexLine.right;
+                    }
+                    drawVerticalDivider(canvas, verticalDividerLeft, paddingTop,
+                            verticalDividerLength);
+                }
+            }
+        }
+    }
+
+    private void drawVerticalDivider(Canvas canvas, int left, int top, int length) {
+        if (mDividerDrawableVertical == null) {
+            return;
+        }
+        mDividerDrawableVertical.setBounds(left, top, left + mDividerVerticalWidth, top + length);
+        mDividerDrawableVertical.draw(canvas);
+    }
+
+    private void drawHorizontalDivider(Canvas canvas, int left, int top, int length) {
+        if (mDividerDrawableHorizontal == null) {
+            return;
+        }
+        mDividerDrawableHorizontal
+                .setBounds(left, top, left + length, top + mDividerHorizontalHeight);
+        mDividerDrawableHorizontal.draw(canvas);
+    }
+
+    @Override
     protected boolean checkLayoutParams(ViewGroup.LayoutParams p) {
         return p instanceof FlexboxLayout.LayoutParams;
     }
@@ -1896,6 +2299,237 @@ public class FlexboxLayout extends ViewGroup {
             mAlignContent = alignContent;
             requestLayout();
         }
+    }
+
+    /**
+     * @return the horizontal divider drawable that will divide each item.
+     * @see #setDividerDrawable(Drawable)
+     * @see #setDividerDrawableHorizontal(Drawable)
+     */
+    public Drawable getDividerDrawableHorizontal() {
+        return mDividerDrawableHorizontal;
+    }
+
+    /**
+     * @return the vertical divider drawable that will divide each item.
+     * @see #setDividerDrawable(Drawable)
+     * @see #setDividerDrawableVertical(Drawable)
+     */
+    public Drawable getDividerDrawableVertical() {
+        return mDividerDrawableVertical;
+    }
+
+    /**
+     * Set a drawable to be used as a divider between items. The drawable is used for both
+     * horizontal and vertical dividers.
+     *
+     * @param divider Drawable that will divide each item for both horizontally and vertically.
+     * @see #setShowDivider(int)
+     */
+    public void setDividerDrawable(Drawable divider) {
+        setDividerDrawableHorizontal(divider);
+        setDividerDrawableVertical(divider);
+    }
+
+    /**
+     * Set a drawable to be used as a horizontal divider between items.
+     *
+     * @param divider Drawable that will divide each item.
+     * @see #setDividerDrawable(Drawable)
+     * @see #setShowDivider(int)
+     * @see #setShowDividerHorizontal(int)
+     */
+    public void setDividerDrawableHorizontal(Drawable divider) {
+        if (divider == mDividerDrawableHorizontal) {
+            return;
+        }
+        mDividerDrawableHorizontal = divider;
+        if (divider != null) {
+            mDividerHorizontalHeight = divider.getIntrinsicHeight();
+        } else {
+            mDividerHorizontalHeight = 0;
+        }
+        setWillNotDrawFlag();
+        requestLayout();
+    }
+
+    /**
+     * Set a drawable to be used as a vertical divider between items.
+     *
+     * @param divider Drawable that will divide each item.
+     * @see #setDividerDrawable(Drawable)
+     * @see #setShowDivider(int)
+     * @see #setShowDividerVertical(int)
+     */
+    public void setDividerDrawableVertical(Drawable divider) {
+        if (divider == mDividerDrawableVertical) {
+            return;
+        }
+        mDividerDrawableVertical = divider;
+        if (divider != null) {
+            mDividerVerticalWidth = divider.getIntrinsicWidth();
+        } else {
+            mDividerVerticalWidth = 0;
+        }
+        setWillNotDrawFlag();
+        requestLayout();
+    }
+
+    @FlexboxLayout.DividerMode
+    public int getShowDividerVertical() {
+        return mShowDividerVertical;
+    }
+
+    @FlexboxLayout.DividerMode
+    public int getShowDividerHorizontal() {
+        return mShowDividerHorizontal;
+    }
+
+    /**
+     * Set how dividers should be shown between items in this layout. This method sets the
+     * divider mode for both horizontally and vertically.
+     *
+     * @param dividerMode One or more of {@link #SHOW_DIVIDER_BEGINNING},
+     *                    {@link #SHOW_DIVIDER_MIDDLE}, or {@link #SHOW_DIVIDER_END},
+     *                    or {@link #SHOW_DIVIDER_NONE} to show no dividers.
+     * @see #setShowDividerVertical(int)
+     * @see #setShowDividerHorizontal(int)
+     */
+    public void setShowDivider(@DividerMode int dividerMode) {
+        setShowDividerVertical(dividerMode);
+        setShowDividerHorizontal(dividerMode);
+    }
+
+    /**
+     * Set how vertical dividers should be shown between items in this layout
+     *
+     * @param dividerMode One or more of {@link #SHOW_DIVIDER_BEGINNING},
+     *                    {@link #SHOW_DIVIDER_MIDDLE}, or {@link #SHOW_DIVIDER_END},
+     *                    or {@link #SHOW_DIVIDER_NONE} to show no dividers.
+     * @see #setShowDivider(int)
+     */
+    public void setShowDividerVertical(@DividerMode int dividerMode) {
+        if (dividerMode != mShowDividerVertical) {
+            mShowDividerVertical = dividerMode;
+            requestLayout();
+        }
+    }
+
+    /**
+     * Set how horizontal dividers should be shown between items in this layout.
+     *
+     * @param dividerMode One or more of {@link #SHOW_DIVIDER_BEGINNING},
+     *                    {@link #SHOW_DIVIDER_MIDDLE}, or {@link #SHOW_DIVIDER_END},
+     *                    or {@link #SHOW_DIVIDER_NONE} to show no dividers.
+     * @see #setShowDivider(int)
+     */
+    public void setShowDividerHorizontal(@DividerMode int dividerMode) {
+        if (dividerMode != mShowDividerHorizontal) {
+            mShowDividerHorizontal = dividerMode;
+            requestLayout();
+        }
+    }
+
+    private void setWillNotDrawFlag() {
+        if (mDividerDrawableHorizontal == null && mDividerDrawableVertical == null) {
+            setWillNotDraw(true);
+        } else {
+            setWillNotDraw(false);
+        }
+    }
+
+    /**
+     * Check if a divider is needed before the view whose indices are passed as arguments.
+     *
+     * @param childAbsoluteIndex           the absolute index of the view to be judged
+     * @param childRelativeIndexInFlexLine the relative index in the flex line where the view
+     *                                     belongs
+     * @return {@code true} if a divider is needed, {@code false} otherwise
+     */
+    private boolean hasDividerBeforeChildAtAlongMainAxis(int childAbsoluteIndex,
+            int childRelativeIndexInFlexLine) {
+        if (allViewsAreGoneBefore(childAbsoluteIndex, childRelativeIndexInFlexLine)) {
+            if (isMainAxisDirectionHorizontal(mFlexDirection)) {
+                return (mShowDividerVertical & SHOW_DIVIDER_BEGINNING) != 0;
+            } else {
+                return (mShowDividerHorizontal & SHOW_DIVIDER_BEGINNING) != 0;
+            }
+        } else {
+            if (isMainAxisDirectionHorizontal(mFlexDirection)) {
+                return (mShowDividerVertical & SHOW_DIVIDER_MIDDLE) != 0;
+            } else {
+                return (mShowDividerHorizontal & SHOW_DIVIDER_MIDDLE) != 0;
+            }
+        }
+    }
+
+    private boolean allViewsAreGoneBefore(int childAbsoluteIndex,
+            int childRelativeIndexInFlexLine) {
+        for (int i = 1; i <= childRelativeIndexInFlexLine; i++) {
+            View view = getReorderedChildAt(childAbsoluteIndex - i);
+            if (view != null && view.getVisibility() != View.GONE) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Check if a divider is needed before the flex line whose index is passed as an argument.
+     *
+     * @param flexLineIndex the index of the flex line to be checked
+     * @return {@code true} if a divider is needed, {@code false} otherwise
+     */
+    private boolean hasDividerBeforeFlexLine(int flexLineIndex) {
+        if (flexLineIndex < 0 || flexLineIndex >= mFlexLines.size()) {
+            return false;
+        }
+        if (allFlexLinesAreDummyBefore(flexLineIndex)) {
+            if (isMainAxisDirectionHorizontal(mFlexDirection)) {
+                return (mShowDividerHorizontal & SHOW_DIVIDER_BEGINNING) != 0;
+            } else {
+                return (mShowDividerVertical & SHOW_DIVIDER_BEGINNING) != 0;
+            }
+        } else {
+            if (isMainAxisDirectionHorizontal(mFlexDirection)) {
+                return (mShowDividerHorizontal & SHOW_DIVIDER_MIDDLE) != 0;
+            } else {
+                return (mShowDividerVertical & SHOW_DIVIDER_MIDDLE) != 0;
+            }
+        }
+    }
+
+    private boolean allFlexLinesAreDummyBefore(int flexLineIndex) {
+        for (int i = 0; i < flexLineIndex; i++) {
+            if (mFlexLines.get(i).itemCount > 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Check if a end divider is needed after the flex line whose index is passed as an argument.
+     *
+     * @param flexLineIndex the index of the flex line to be checked
+     * @return {@code true} if a divider is needed, {@code false} otherwise
+     */
+    private boolean hasEndDividerAfterFlexLine(int flexLineIndex) {
+        if (flexLineIndex < 0 || flexLineIndex >= mFlexLines.size()) {
+            return false;
+        }
+
+        for (int i = flexLineIndex + 1; i < mFlexLines.size(); i++) {
+            if (mFlexLines.get(i).itemCount > 0) {
+                return false;
+            }
+        }
+        if (isMainAxisDirectionHorizontal(mFlexDirection)) {
+            return (mShowDividerHorizontal & SHOW_DIVIDER_END) != 0;
+        } else {
+            return (mShowDividerVertical & SHOW_DIVIDER_END) != 0;
+        }
+
     }
 
     /**
@@ -2086,7 +2720,37 @@ public class FlexboxLayout extends ViewGroup {
      */
     private static class FlexLine {
 
+        /**
+         * The distance in pixels from the left edge of this view's parent
+         * to the left edge of this FlexLine.
+         */
+        int left = Integer.MAX_VALUE;
+
+        /**
+         * The distance in pixels from the top edge of this view's parent
+         * to the top edge of this FlexLine.
+         */
+        int top = Integer.MAX_VALUE;
+
+        /**
+         * The distance in pixels from the right edge of this view's parent
+         * to the right edge of this FlexLine.
+         */
+        int right = Integer.MIN_VALUE;
+
+        /**
+         * The distance in pixels from the bottom edge of this view's parent
+         * to the bottom edge of this FlexLine.
+         */
+        int bottom = Integer.MIN_VALUE;
+
         int mainSize;
+
+        /**
+         * The sum of the lengths of dividers along the main axis. This value should be lower or
+         * than than the value of {@link #mainSize}.
+         */
+        int dividerLengthInMainSize;
 
         int crossSize;
 

--- a/flexbox/src/main/res/values/attrs.xml
+++ b/flexbox/src/main/res/values/attrs.xml
@@ -58,6 +58,29 @@ limitations under the License.
             <enum name="space_around" value="4" />
             <enum name="stretch" value="5" />
         </attr>
+
+        <attr name="dividerDrawable" format="reference" />
+        <attr name="dividerDrawableHorizontal" format="reference" />
+        <attr name="dividerDrawableVertical" format="reference" />
+
+        <attr name="showDivider">
+            <flag name="none" value="0" />
+            <flag name="beginning" value="1" />
+            <flag name="middle" value="2" />
+            <flag name="end" value="4" />
+        </attr>
+        <attr name="showDividerHorizontal">
+            <flag name="none" value="0" />
+            <flag name="beginning" value="1" />
+            <flag name="middle" value="2" />
+            <flag name="end" value="4" />
+        </attr>
+        <attr name="showDividerVertical">
+            <flag name="none" value="0" />
+            <flag name="beginning" value="1" />
+            <flag name="middle" value="2" />
+            <flag name="end" value="4" />
+        </attr>
     </declare-styleable>
 
     <declare-styleable name="FlexboxLayout_Layout">


### PR DESCRIPTION
This PR adds the attributes to put horizontal/vertical dividers that can be used like fixed size of margins between flex lines (or flex items).
(The attributes don't work well with the existing attributes that put spaces between flex items or flex lines, such as justifyContent="space_around", alignContent="space_between" ... etc)

```
showDivider
showDividerHorizontal
showDividerVertical
dividerDrawable
dividerDrawableHorizontal
dividerDrawableVertical
```

I'm going to modify the README to explain the attributes added in this PR.