### PR TITLE
Accept float value as Flex Grow/Shrink on the sample application

### DIFF
--- a/app/src/androidTest/java/com/google/android/apps/flexbox/test/MainActivityTest.java
+++ b/app/src/androidTest/java/com/google/android/apps/flexbox/test/MainActivityTest.java
@@ -332,6 +332,26 @@ public class MainActivityTest {
 
     @Test
     @FlakyTest(tolerance = TOLERANCE)
+    public void testEditFragment_changeFlexGrowFloat() {
+        MainActivity activity = mActivityRule.getActivity();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertNotNull(flexboxLayout);
+        onView(withId(R.id.textview1)).perform(click());
+        onView(withId(R.id.edit_text_flex_grow)).perform(replaceText("1.0"), closeSoftKeyboard());
+        onView(withId(R.id.button_ok)).perform(click());
+        TextView first = (TextView) activity.findViewById(R.id.textview1);
+        TextView second = (TextView) activity.findViewById(R.id.textview2);
+        TextView third = (TextView) activity.findViewById(R.id.textview3);
+        assertNotNull(first);
+        assertNotNull(second);
+        assertNotNull(third);
+
+        assertThat(first.getWidth(),
+                is(flexboxLayout.getWidth() - second.getWidth() - third.getWidth()));
+    }
+
+    @Test
+    @FlakyTest(tolerance = TOLERANCE)
     public void testEditFragment_changeFlexBasisPercent() {
         MainActivity activity = mActivityRule.getActivity();
         FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);

--- a/app/src/main/java/com/google/android/apps/flexbox/FlexItemEditFragment.java
+++ b/app/src/main/java/com/google/android/apps/flexbox/FlexItemEditFragment.java
@@ -371,47 +371,59 @@ public class FlexItemEditFragment extends DialogFragment {
                     !mInputValidator.isValidInput(editable.toString())) {
                 return;
             }
-            int intValue;
-            try {
-                intValue = Integer.valueOf(editable.toString());
-            } catch (NumberFormatException | NullPointerException ignore) {
-                return;
+            final Number value;
+            switch (mTextInputLayout.getId()) {
+                case R.id.input_layout_flex_grow:
+                case R.id.input_layout_flex_shrink:
+                    try {
+                        value = Float.valueOf(editable.toString());
+                    } catch (NumberFormatException | NullPointerException ignore) {
+                        return;
+                    }
+                    break;
+                default:
+                    try {
+                        value = Integer.valueOf(editable.toString());
+                    } catch (NumberFormatException | NullPointerException ignore) {
+                        return;
+                    }
             }
+
             switch (mTextInputLayout.getId()) {
                 case R.id.input_layout_order:
-                    mFlexItem.order = intValue;
+                    mFlexItem.order = value.intValue();
                     break;
                 case R.id.input_layout_flex_grow:
-                    mFlexItem.flexGrow = intValue;
+                    mFlexItem.flexGrow = value.floatValue();
                     break;
                 case R.id.input_layout_flex_shrink:
-                    mFlexItem.flexShrink = intValue;
+                    mFlexItem.flexShrink = value.floatValue();
                     break;
                 case R.id.input_layout_width:
-                    mFlexItem.width = intValue;
+                    mFlexItem.width = value.intValue();
                     break;
                 case R.id.input_layout_height:
-                    mFlexItem.height = intValue;
+                    mFlexItem.height = value.intValue();
                     break;
                 case R.id.input_layout_flex_basis_percent:
-                    if (intValue != FlexboxLayout.LayoutParams.FLEX_BASIS_PERCENT_DEFAULT) {
-                        mFlexItem.flexBasisPercent = (float) (intValue / 100.0);
+                    if (value.intValue() != FlexboxLayout.LayoutParams.FLEX_BASIS_PERCENT_DEFAULT) {
+                        mFlexItem.flexBasisPercent = (float) (value.intValue() / 100.0);
                     } else {
                         mFlexItem.flexBasisPercent
                                 = FlexboxLayout.LayoutParams.FLEX_BASIS_PERCENT_DEFAULT;
                     }
                     break;
                 case R.id.input_layout_min_width:
-                    mFlexItem.minWidth = intValue;
+                    mFlexItem.minWidth = value.intValue();
                     break;
                 case R.id.input_layout_min_height:
-                    mFlexItem.minHeight = intValue;
+                    mFlexItem.minHeight = value.intValue();
                     break;
                 case R.id.input_layout_max_width:
-                    mFlexItem.maxWidth = intValue;
+                    mFlexItem.maxWidth = value.intValue();
                     break;
                 case R.id.input_layout_max_height:
-                    mFlexItem.maxHeight = intValue;
+                    mFlexItem.maxHeight = value.intValue();
                     break;
             }
         }


### PR DESCRIPTION
Fix for #112 

- Add a UT to input a float value as Flex Grow.
- Parse the input value as float for Flex Grow and Flex Shrink, parse the value as int for the others.