### PR TITLE
Add the dialog theme for Honeycomb

### DIFF
--- a/app/src/main/java/com/google/android/apps/flexbox/FlexItemEditFragment.java
+++ b/app/src/main/java/com/google/android/apps/flexbox/FlexItemEditFragment.java
@@ -86,6 +86,8 @@ public class FlexItemEditFragment extends DialogFragment {
         super.onCreate(savedInstanceState);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             setStyle(DialogFragment.STYLE_NORMAL, android.R.style.Theme_Material_Light_Dialog);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            setStyle(DialogFragment.STYLE_NORMAL, android.R.style.Theme_Holo_Light_Dialog);
         } else {
             setStyle(DialogFragment.STYLE_NORMAL, android.R.style.Theme_Dialog);
         }


### PR DESCRIPTION
This change is

- fix #115 
- Add the theme of `android.R.style.Theme_Holo_Light_Dialog`

and the result is

![device-2016-09-04-010200](https://cloud.githubusercontent.com/assets/1404787/18226219/e2592460-723f-11e6-866e-049b0271a081.png)

@thagikura if you would like, please use this PR.