### PR TITLE
Remove dummy flex lines from the result of `FlexLayout#getFlexLines`.

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
@@ -1423,6 +1423,7 @@ public class FlexboxAndroidTest {
                 && textView1.getTop() <= spaceAboveAndBottom + 1);
         assertTrue(flexboxLayout.getBottom() - spaceAboveAndBottom - 1 <= textView3.getBottom() &&
                 textView3.getBottom() <= flexboxLayout.getBottom() - spaceAboveAndBottom + 1);
+        assertThat(flexboxLayout.getFlexLines().size(), is(2));
     }
 
     @Test
@@ -1447,6 +1448,7 @@ public class FlexboxAndroidTest {
         onView(withId(R.id.text2)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
         onView(withId(R.id.text3)).check(isBottomAlignedWith(withId(R.id.flexbox_layout)));
         onView(withId(R.id.text3)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+        assertThat(flexboxLayout.getFlexLines().size(), is(2));
     }
 
     @Test
@@ -1503,6 +1505,7 @@ public class FlexboxAndroidTest {
         int spaceLowerBound = textView1.getBottom() + spaceAround * 2 - 1;
         int spaceUpperBound = textView1.getBottom() + spaceAround * 2 + 1;
         assertTrue(spaceLowerBound <= textView3.getTop() && textView3.getTop() <= spaceUpperBound);
+        assertThat(flexboxLayout.getFlexLines().size(), is(2));
     }
 
     @Test
@@ -1538,6 +1541,7 @@ public class FlexboxAndroidTest {
         TextView textView1 = (TextView) activity.findViewById(R.id.text1);
         TextView textView3 = (TextView) activity.findViewById(R.id.text3);
         assertThat(textView3.getTop(), is(textView1.getHeight()));
+        assertThat(flexboxLayout.getFlexLines().size(), is(2));
     }
 
     @Test

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
@@ -2322,11 +2322,20 @@ public class FlexboxLayout extends ViewGroup {
     }
 
     /**
-     * @return the flex lines composing this flex container. This method returns an unmodifiable
-     * list. Thus any changes of the returned list are not supported.
+     * @return the flex lines composing this flex container. This method returns a copy of the
+     * original list excluding a dummy flex line (flex line that doesn't have any flex items in it
+     * but used for the alignment along the cross axis).
+     * Thus any changes of the returned list are not reflected to the original list.
      */
     public List<FlexLine> getFlexLines() {
-        return Collections.unmodifiableList(mFlexLines);
+        List<FlexLine> result = new ArrayList<>(mFlexLines.size());
+        for (FlexLine flexLine : mFlexLines) {
+            if (flexLine.getItemCount() == 0) {
+                continue;
+            }
+            result.add(flexLine);
+        }
+        return result;
     }
 
     /**


### PR DESCRIPTION
Fixes #117

Remove dummy flex lines from the result of `FlexLayout#getFlexLines`.
