### PR TITLE
Add RecyclerView fragment to the demo app

### DIFF
--- a/app/src/main/java/com/google/android/apps/flexbox/FlexboxLayoutFragment.java
+++ b/app/src/main/java/com/google/android/apps/flexbox/FlexboxLayoutFragment.java
@@ -22,9 +22,12 @@ import com.google.android.flexbox.FlexContainer;
 import com.google.android.flexbox.FlexItem;
 import com.google.android.flexbox.FlexboxLayout;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.Fragment;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -54,10 +57,10 @@ public class FlexboxLayoutFragment extends Fragment {
 
     @Override
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
-        MainActivity activity = (MainActivity) getActivity();
+        final MainActivity activity = (MainActivity) getActivity();
         mFlexContainer = (FlexboxLayout) view.findViewById(R.id.flexbox_layout);
 
-        FragmentHelper fragmentHelper = new FragmentHelper(activity, mFlexContainer);
+        final FragmentHelper fragmentHelper = new FragmentHelper(activity, mFlexContainer);
         fragmentHelper.initializeViews();
         if (savedInstanceState != null) {
             ArrayList<FlexItem> flexItems = savedInstanceState
@@ -66,7 +69,7 @@ public class FlexboxLayoutFragment extends Fragment {
             mFlexContainer.removeAllViews();
             for (int i = 0; i < flexItems.size(); i++) {
                 FlexItem flexItem = flexItems.get(i);
-                TextView textView = fragmentHelper.createBaseFlexItemTextView(i);
+                TextView textView = createBaseFlexItemTextView(activity, i);
                 textView.setLayoutParams((FlexboxLayout.LayoutParams) flexItem);
                 mFlexContainer.addView(textView);
             }
@@ -76,6 +79,40 @@ public class FlexboxLayoutFragment extends Fragment {
                         new FlexItemClickListener(activity,
                                 new FlexItemChangedListenerImpl(mFlexContainer), i));
             }
+        }
+
+        FloatingActionButton addFab = (FloatingActionButton) activity.findViewById(R.id.add_fab);
+        if (addFab != null) {
+            addFab.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    int viewIndex = mFlexContainer.getChildCount();
+                    // index starts from 0. New View's index is N if N views ([0, 1, 2, ... N-1])
+                    // exist.
+                    TextView textView = createBaseFlexItemTextView(activity, viewIndex);
+                    FlexboxLayout.LayoutParams lp = new FlexboxLayout.LayoutParams(
+                            ViewGroup.LayoutParams.WRAP_CONTENT,
+                            ViewGroup.LayoutParams.WRAP_CONTENT);
+                    fragmentHelper.setFlexItemAttributes(lp);
+                    textView.setLayoutParams(lp);
+                    textView.setOnClickListener(new FlexItemClickListener(activity,
+                            new FlexItemChangedListenerImpl(mFlexContainer), viewIndex));
+                    mFlexContainer.addView(textView);
+                }
+            });
+        }
+        FloatingActionButton removeFab = (FloatingActionButton) activity.findViewById(
+                R.id.remove_fab);
+        if (removeFab != null) {
+            removeFab.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if (mFlexContainer.getChildCount() == 0) {
+                        return;
+                    }
+                    mFlexContainer.removeViewAt(mFlexContainer.getChildCount() - 1);
+                }
+            });
         }
     }
 
@@ -88,5 +125,13 @@ public class FlexboxLayoutFragment extends Fragment {
             flexItems.add((FlexItem) child.getLayoutParams());
         }
         outState.putParcelableArrayList(FLEX_ITEMS_KEY, flexItems);
+    }
+
+    private TextView createBaseFlexItemTextView(Context context, int index) {
+        TextView textView = new TextView(context);
+        textView.setBackgroundResource(R.drawable.flex_item_background);
+        textView.setText(String.valueOf(index + 1));
+        textView.setGravity(Gravity.CENTER);
+        return textView;
     }
 }

--- a/app/src/main/java/com/google/android/apps/flexbox/FragmentHelper.java
+++ b/app/src/main/java/com/google/android/apps/flexbox/FragmentHelper.java
@@ -16,28 +16,23 @@
 
 package com.google.android.apps.flexbox;
 
-import com.google.android.apps.flexbox.listeners.FlexItemChangedListenerImpl;
-import com.google.android.apps.flexbox.listeners.FlexItemClickListener;
 import com.google.android.flexbox.AlignContent;
 import com.google.android.flexbox.AlignItems;
 import com.google.android.flexbox.FlexContainer;
 import com.google.android.flexbox.FlexDirection;
+import com.google.android.flexbox.FlexItem;
 import com.google.android.flexbox.FlexWrap;
-import com.google.android.flexbox.FlexboxLayout;
 import com.google.android.flexbox.JustifyContent;
 
 import android.content.SharedPreferences;
-import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.NavigationView;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v7.preference.PreferenceManager;
-import android.view.Gravity;
 import android.view.Menu;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Spinner;
-import android.widget.TextView;
 
 /**
  * Helper class that has the common logic for initializing the Fragment for the play ground demo
@@ -45,9 +40,9 @@ import android.widget.TextView;
  */
 class FragmentHelper {
 
-    private static final String DEFAULT_WIDTH = "120";
+    static final String DEFAULT_WIDTH = "120";
 
-    private static final String DEFAULT_HEIGHT = "80";
+    static final String DEFAULT_HEIGHT = "80";
 
     private String ROW;
 
@@ -101,36 +96,6 @@ class FragmentHelper {
             initializeAlignItemsSpinner(navigationMenu);
             initializeAlignContentSpinner(navigationMenu);
         }
-
-        FloatingActionButton addFab = (FloatingActionButton) mActivity.findViewById(R.id.add_fab);
-        if (addFab != null) {
-            addFab.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    int viewIndex = mFlexContainer.getChildCount();
-                    // index starts from 0. New View's index is N if N views ([0, 1, 2, ... N-1])
-                    // exist.
-                    TextView textView = createBaseFlexItemTextView(viewIndex);
-                    textView.setLayoutParams(createDefaultLayoutParams());
-                    textView.setOnClickListener(new FlexItemClickListener(mActivity,
-                            new FlexItemChangedListenerImpl(mFlexContainer), viewIndex));
-                    mFlexContainer.addView(textView);
-                }
-            });
-        }
-        FloatingActionButton removeFab = (FloatingActionButton) mActivity.findViewById(
-                R.id.remove_fab);
-        if (removeFab != null) {
-            removeFab.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    if (mFlexContainer.getChildCount() == 0) {
-                        return;
-                    }
-                    mFlexContainer.removeViewAt(mFlexContainer.getChildCount() - 1);
-                }
-            });
-        }
     }
 
     private void initializeStringResources() {
@@ -150,38 +115,32 @@ class FragmentHelper {
         SPACE_AROUND = mActivity.getString(R.string.space_around);
     }
 
-    TextView createBaseFlexItemTextView(int index) {
-        TextView textView = new TextView(mActivity);
-        textView.setBackgroundResource(R.drawable.flex_item_background);
-        textView.setText(String.valueOf(index + 1));
-        textView.setGravity(Gravity.CENTER);
-        return textView;
-    }
-
     /**
-     * Creates a new {@link FlexboxLayout.LayoutParams} based on the stored default values in
+     * Sets the attributes for a {@link FlexItem} based on the stored default values in
      * the SharedPreferences.
      *
-     * @return a {@link FlexboxLayout.LayoutParams} instance
+     * @param flexItem the FlexItem instance
+     * @return a FlexItem instance, which attributes from the SharedPreferences are updated
      */
-    private FlexboxLayout.LayoutParams createDefaultLayoutParams() {
-        FlexboxLayout.LayoutParams lp = new FlexboxLayout.LayoutParams(
-                Util.dpToPixel(mActivity,
-                        readPreferenceAsInteger(mActivity.getString(R.string.new_width_key),
-                                DEFAULT_WIDTH)),
-                Util.dpToPixel(mActivity,
-                        readPreferenceAsInteger(mActivity.getString(R.string.new_height_key),
-                                DEFAULT_HEIGHT)));
-        lp.setOrder(readPreferenceAsInteger(mActivity.getString(R.string.new_flex_item_order_key),
-                "1"));
-        lp.setFlexGrow(
+    FlexItem setFlexItemAttributes(FlexItem flexItem) {
+        flexItem.setWidth(Util.dpToPixel(mActivity,
+                readPreferenceAsInteger(mActivity.getString(R.string.new_width_key),
+                        DEFAULT_WIDTH)));
+        flexItem.setHeight(Util.dpToPixel(mActivity,
+                readPreferenceAsInteger(mActivity.getString(R.string.new_height_key),
+                        DEFAULT_HEIGHT)));
+        flexItem.setOrder(
+                readPreferenceAsInteger(mActivity.getString(R.string.new_flex_item_order_key),
+                        "1"));
+        flexItem.setFlexGrow(
                 readPreferenceAsFloat(mActivity.getString(R.string.new_flex_grow_key), "0.0"));
-        lp.setFlexShrink(
+        flexItem.setFlexShrink(
                 readPreferenceAsFloat(mActivity.getString(R.string.new_flex_shrink_key), "1.0"));
         int flexBasisPercent = readPreferenceAsInteger(
                 mActivity.getString(R.string.new_flex_basis_percent_key), "-1");
-        lp.setFlexBasisPercent(flexBasisPercent == -1 ? -1 : (float) (flexBasisPercent / 100.0));
-        return lp;
+        flexItem.setFlexBasisPercent(
+                flexBasisPercent == -1 ? -1 : (float) (flexBasisPercent / 100.0));
+        return flexItem;
     }
 
     private int readPreferenceAsInteger(String key, String defValue) {

--- a/app/src/main/java/com/google/android/apps/flexbox/MainActivity.java
+++ b/app/src/main/java/com/google/android/apps/flexbox/MainActivity.java
@@ -27,11 +27,14 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.widget.RadioGroup;
 
 public class MainActivity extends AppCompatActivity
         implements NavigationView.OnNavigationItemSelectedListener {
 
     private static final String FLEXBOXLAYOUT_FRAGMENT = "flexboxlayout_fragment";
+
+    private static final String RECYCLERVIEW_FRAGMENT = "recyclerview_fragment";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -49,9 +52,31 @@ public class MainActivity extends AppCompatActivity
         }
         toggle.syncState();
 
-        // TODO: Add another Fragment that contains RecyclerView in it and switch the Fragment
-        //       between the two implementations.
-        FragmentManager fragmentManager = getSupportFragmentManager();
+        NavigationView navigationView = (NavigationView) findViewById(R.id.nav_view);
+        RadioGroup radioGroup = (RadioGroup) navigationView.getHeaderView(0)
+                .findViewById(R.id.radiogroup_container_implementation);
+        final FragmentManager fragmentManager = getSupportFragmentManager();
+        radioGroup.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(RadioGroup radioGroup, int checkedId) {
+                if (checkedId == R.id.radiobutton_viewgroup) {
+                    replaceToFlexboxLayoutFragment(fragmentManager);
+                } else {
+                    RecyclerViewFragment fragment = (RecyclerViewFragment)
+                            fragmentManager.findFragmentByTag(RECYCLERVIEW_FRAGMENT);
+                    if (fragment == null) {
+                        fragment = RecyclerViewFragment.newInstance();
+                    }
+                    fragmentManager.beginTransaction()
+                            .replace(R.id.container, fragment, RECYCLERVIEW_FRAGMENT).commit();
+                }
+            }
+        });
+
+        replaceToFlexboxLayoutFragment(fragmentManager);
+    }
+
+    private void replaceToFlexboxLayoutFragment(FragmentManager fragmentManager) {
         FlexboxLayoutFragment fragment = (FlexboxLayoutFragment)
                 fragmentManager.findFragmentByTag(FLEXBOXLAYOUT_FRAGMENT);
         if (fragment == null) {

--- a/app/src/main/java/com/google/android/apps/flexbox/RecyclerViewFragment.java
+++ b/app/src/main/java/com/google/android/apps/flexbox/RecyclerViewFragment.java
@@ -1,0 +1,75 @@
+package com.google.android.apps.flexbox;
+
+import com.google.android.apps.flexbox.recyclerview.FlexItemAdapter;
+import com.google.android.flexbox.FlexItem;
+import com.google.android.flexbox.FlexboxLayoutManager;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.design.widget.FloatingActionButton;
+import android.support.v4.app.Fragment;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+/**
+ * Fragment that contains the {@link RecyclerView} and the {@link FlexboxLayoutManager} as its
+ * LayoutManager for the flexbox playground.
+ */
+public class RecyclerViewFragment extends Fragment {
+
+    public static RecyclerViewFragment newInstance() {
+        return new RecyclerViewFragment();
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
+            @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_recyclerview, container, false);
+    }
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        RecyclerView recyclerView = (RecyclerView) view.findViewById(R.id.recyclerview);
+        final FlexboxLayoutManager flexboxLayoutManager = new FlexboxLayoutManager();
+        recyclerView.setLayoutManager(flexboxLayoutManager);
+        final FlexItemAdapter adapter = new FlexItemAdapter();
+        recyclerView.setAdapter(adapter);
+
+        final MainActivity activity = (MainActivity) getActivity();
+        final FragmentHelper fragmentHelper = new FragmentHelper(activity, flexboxLayoutManager);
+        fragmentHelper.initializeViews();
+        FloatingActionButton addFab = (FloatingActionButton) activity.findViewById(R.id.add_fab);
+        if (addFab != null) {
+            addFab.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    FlexItem flexItem = new FlexboxLayoutManager.LayoutParams(
+                            ViewGroup.LayoutParams.WRAP_CONTENT,
+                            ViewGroup.LayoutParams.WRAP_CONTENT);
+                    fragmentHelper.setFlexItemAttributes(flexItem);
+                    adapter.addFlexItem(flexItem);
+                    // TODO: Specify index?
+                    adapter.notifyDataSetChanged();
+                }
+            });
+        }
+        FloatingActionButton removeFab = (FloatingActionButton) activity.findViewById(
+                R.id.remove_fab);
+        if (removeFab != null) {
+            removeFab.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if (flexboxLayoutManager.getChildCount() == 0) {
+                        return;
+                    }
+                    flexboxLayoutManager.removeViewAt(flexboxLayoutManager.getChildCount() - 1);
+                }
+            });
+        }
+    }
+}

--- a/app/src/main/java/com/google/android/apps/flexbox/recyclerview/FlexItemAdapter.java
+++ b/app/src/main/java/com/google/android/apps/flexbox/recyclerview/FlexItemAdapter.java
@@ -1,0 +1,59 @@
+package com.google.android.apps.flexbox.recyclerview;
+
+import com.google.android.apps.flexbox.R;
+import com.google.android.flexbox.FlexItem;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link RecyclerView.Adapter} implementation for {@link FlexItemViewHolder}.
+ */
+public class FlexItemAdapter extends RecyclerView.Adapter<FlexItemViewHolder> {
+
+    private List<FlexItem> mFlexItems;
+
+    public FlexItemAdapter() {
+        this(new ArrayList<FlexItem>());
+    }
+
+    public FlexItemAdapter(List<FlexItem> flexItems) {
+        mFlexItems = flexItems;
+    }
+
+    @Override
+    public FlexItemViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.viewholder_flex_item, parent, false);
+        return new FlexItemViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(FlexItemViewHolder holder, int position) {
+        holder.mTextView.setText(String.valueOf(position + 1));
+        holder.mTextView.setBackgroundResource(R.drawable.flex_item_background);
+        holder.mTextView.setGravity(Gravity.CENTER);
+    }
+
+    public void addFlexItem(FlexItem flexItem) {
+        mFlexItems.add(flexItem);
+    }
+
+    public void removeFlexItem(int position) {
+        if (position < 0 || position >= mFlexItems.size()) {
+            return;
+        }
+        mFlexItems.remove(position);
+    }
+
+    @Override
+    public int getItemCount() {
+        return mFlexItems.size();
+    }
+}

--- a/app/src/main/java/com/google/android/apps/flexbox/recyclerview/FlexItemViewHolder.java
+++ b/app/src/main/java/com/google/android/apps/flexbox/recyclerview/FlexItemViewHolder.java
@@ -1,0 +1,21 @@
+package com.google.android.apps.flexbox.recyclerview;
+
+import com.google.android.apps.flexbox.R;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.TextView;
+
+/**
+ * ViewHolder implementation for a flex item.
+ */
+public class FlexItemViewHolder extends RecyclerView.ViewHolder {
+
+    TextView mTextView;
+
+    public FlexItemViewHolder(View itemView) {
+        super(itemView);
+
+        mTextView = (TextView) itemView.findViewById(R.id.textview);
+    }
+}

--- a/app/src/main/res/layout/fragment_recyclerview.xml
+++ b/app/src/main/res/layout/fragment_recyclerview.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+Copyright 2016 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<android.support.v7.widget.RecyclerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/recyclerview"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/nav_header_height"
+    android:layout_height="wrap_content"
     android:background="@drawable/side_nav_bar"
     android:paddingBottom="@dimen/activity_vertical_margin"
     android:paddingLeft="@dimen/activity_horizontal_margin"
@@ -39,4 +39,28 @@ limitations under the License.
         android:text="@string/app_name"
         android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
 
+    <RadioGroup
+        android:id="@+id/radiogroup_container_implementation"
+        android:checkedButton="@+id/radiobutton_viewgroup"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_large">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/underlying_implementation" />
+
+        <RadioButton
+            android:id="@+id/radiobutton_viewgroup"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/viewgroup" />
+
+        <RadioButton
+            android:id="@+id/radiobutton_recyclerview"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/recyclerview" />
+    </RadioGroup>
 </LinearLayout>

--- a/app/src/main/res/layout/viewholder_flex_item.xml
+++ b/app/src/main/res/layout/viewholder_flex_item.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+Copyright 2016 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/textview"
+        android:layout_width="@dimen/flex_item_length2"
+        android:layout_height="@dimen/flex_item_length" />
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,4 +127,8 @@ limitations under the License.
     <string name="size_unit_summary">(-1: match_parent, -2: wrap_content)</string>
     <string name="new_width_key" translatable="false">new_width_key</string>
     <string name="new_height_key" translatable="false">new_height_key</string>
+
+    <string name="viewgroup">ViewGroup</string>
+    <string name="recyclerview">RecyclerView</string>
+    <string name="underlying_implementation">Underlying implementation</string>
 </resources>


### PR DESCRIPTION
This PR adds a Fragment that contains RecyclerView as its playground implementation.
And from the RadioGroup in the navigation view, two implementations can be switched (ViewGroup and RecyclerView).

The FlexboxLayoutManager doesn't have any layout/measurement logic at all. Thus when the Fragment for RecyclerView is chosen, no views are displayed regardless of the items in the adapter.