### PR TITLE
Fix the invalid height in the following situation:

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
@@ -3742,6 +3742,55 @@ public class FlexboxAndroidTest {
         assertThat(text3.getRight(), is(text1.getWidth() + text3.getWidth()));
     }
 
+    @Test
+    @FlakyTest
+    public void testZeroWidth_wrapContentHeight_positiveFlexGrow() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_zero_width_positive_flexgrow);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_ROW));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text2 = (TextView) activity.findViewById(R.id.text2);
+        // Both text view's layout_width is set to 0dp, layout_height is set to wrap_content and
+        // layout_flexGrow is set to 1. And the text2 has a longer text than the text1.
+        // So if the cross size calculation (height) is wrong, the height of two text view do not
+        // match because text2 is trying to expand vertically.
+        // This assertion verifies that isn't happening. Finally both text views expand horizontally
+        // enough to contain their texts in one line.
+        assertThat(text1.getHeight(), is(text2.getHeight()));
+        assertThat(text1.getWidth() + text2.getWidth(),
+                isEqualAllowingError(flexboxLayout.getWidth()));
+    }
+
+    @Test
+    @FlakyTest
+    public void testZeroHeight_wrapContentWidth_positiveFlexGrow() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_zero_height_positive_flexgrow);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        TextView text2 = (TextView) activity.findViewById(R.id.text2);
+        assertThat(text1.getWidth(), is(not(text2.getWidth())));
+        assertThat(text1.getHeight() + text2.getHeight(),
+                isEqualAllowingError(flexboxLayout.getHeight()));
+    }
+
     private TextView createTextView(Context context, String text, int order) {
         TextView textView = new TextView(context);
         textView.setText(text);

--- a/flexbox/src/androidTest/res/layout/activity_zero_height_positive_flexgrow.xml
+++ b/flexbox/src/androidTest/res/layout/activity_zero_height_positive_flexgrow.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2016 Google Inc. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    app:flexDirection="column"
+    app:alignItems="flex_start" >
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:text="1"
+        app:layout_flexGrow="1" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:text="2-some long text"
+        app:layout_flexGrow="1" />
+
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/androidTest/res/layout/activity_zero_width_positive_flexgrow.xml
+++ b/flexbox/src/androidTest/res/layout/activity_zero_width_positive_flexgrow.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2016 Google Inc. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:alignItems="flex_start" >
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="1"
+        app:layout_flexGrow="1" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="2-some long text"
+        app:layout_flexGrow="1" />
+
+</com.google.android.flexbox.FlexboxLayout>


### PR DESCRIPTION
- flex direction is set to row (or row_reverse)
- FlexboxLayout has a TextView (or other views that expand vertically if
  not enough space is left horizontally)
- TextView's layout_width is set to 0dp, layout_height is set to wrap_content and
  layout_flexGrow is set to positive

In the situation above, the initial height of the TextView is calculated
as bigger than the actual height because at first the width is set to 0dp,
so the TextView is trying to expand vertically, but actually the height
needs to be measured again with the expanded width.

Fixes #139 