### PR TITLE
Fix the centering positin of the following case to be consistent with the original CSS spec.

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
@@ -3791,6 +3791,50 @@ public class FlexboxAndroidTest {
                 isEqualAllowingError(flexboxLayout.getHeight()));
     }
 
+    @Test
+    @FlakyTest
+    public void testFlexDirection_row_alignItems_center_margin_oneSide() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(
+                        R.layout.activity_direction_row_align_items_center_margin_oneside);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_ROW));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        assertThat(text1.getTop(), isEqualAllowingError(TestUtil.dpToPixel(activity, 30)));
+        assertThat(flexboxLayout.getBottom() - text1.getBottom(),
+                isEqualAllowingError(TestUtil.dpToPixel(activity, 50)));
+    }
+
+    @Test
+    @FlakyTest
+    public void testFlexDirection_column_alignItems_center_margin_oneSide() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(
+                        R.layout.activity_direction_column_align_items_center_margin_oneside);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+        assertThat(flexboxLayout.getFlexDirection(), is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+
+        TextView text1 = (TextView) activity.findViewById(R.id.text1);
+        assertThat(text1.getLeft(), isEqualAllowingError(TestUtil.dpToPixel(activity, 30)));
+        assertThat(flexboxLayout.getRight() - text1.getRight(),
+                isEqualAllowingError(TestUtil.dpToPixel(activity, 50)));
+    }
+
     private TextView createTextView(Context context, String text, int order) {
         TextView textView = new TextView(context);
         textView.setText(text);

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/TestUtil.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/TestUtil.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.flexbox.test;
+
+import android.content.Context;
+import android.util.DisplayMetrics;
+
+/**
+ * Utility class for tests.
+ */
+class TestUtil {
+
+    static int dpToPixel(Context context, int dp) {
+        DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
+        return dp < 0 ? dp : Math.round(dp * displayMetrics.density);
+    }
+}

--- a/flexbox/src/androidTest/res/layout/activity_direction_column_align_items_center_margin_oneside.xml
+++ b/flexbox/src/androidTest/res/layout/activity_direction_column_align_items_center_margin_oneside.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2016 Google Inc. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="100dp"
+    android:layout_height="20dp"
+    app:flexDirection="column">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="20dp"
+        android:layout_height="match_parent"
+        android:layout_marginRight="20dp"
+        android:text="1"
+        app:layout_alignSelf="center" />
+
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/androidTest/res/layout/activity_direction_row_align_items_center_margin_oneside.xml
+++ b/flexbox/src/androidTest/res/layout/activity_direction_row_align_items_center_margin_oneside.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2016 Google Inc. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="20dp"
+    android:layout_height="100dp"
+    app:flexDirection="row">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="match_parent"
+        android:layout_height="20dp"
+        android:layout_marginBottom="20dp"
+        android:text="1"
+        app:layout_alignSelf="center" />
+
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
@@ -22,6 +22,7 @@ import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
+import android.support.v4.view.MarginLayoutParamsCompat;
 import android.support.v4.view.ViewCompat;
 import android.util.AttributeSet;
 import android.util.SparseIntArray;
@@ -1868,15 +1869,14 @@ public class FlexboxLayout extends ViewGroup {
                 }
                 break;
             case ALIGN_ITEMS_CENTER:
-                int topFromCrossAxis = (crossSize - view.getMeasuredHeight()) / 2;
+                int topFromCrossAxis = (crossSize - view.getMeasuredHeight()
+                        + lp.topMargin - lp.bottomMargin) / 2;
                 if (flexWrap != FLEX_WRAP_WRAP_REVERSE) {
-                    view.layout(left, top + topFromCrossAxis + lp.topMargin - lp.bottomMargin,
-                            right, top + topFromCrossAxis + view.getMeasuredHeight() + lp.topMargin
-                                    - lp.bottomMargin);
+                    view.layout(left, top + topFromCrossAxis,
+                            right, top + topFromCrossAxis + view.getMeasuredHeight());
                 } else {
-                    view.layout(left, top - topFromCrossAxis + lp.topMargin - lp.bottomMargin,
-                            right, top - topFromCrossAxis + view.getMeasuredHeight() + lp.topMargin
-                                    - lp.bottomMargin);
+                    view.layout(left, top - topFromCrossAxis,
+                            right, top - topFromCrossAxis + view.getMeasuredHeight());
                 }
                 break;
         }
@@ -2074,15 +2074,13 @@ public class FlexboxLayout extends ViewGroup {
                 }
                 break;
             case ALIGN_ITEMS_CENTER:
-                int leftFromCrossAxis = (crossSize - view.getMeasuredWidth()) / 2;
+                int leftFromCrossAxis = (crossSize - view.getMeasuredWidth()
+                        + MarginLayoutParamsCompat.getMarginStart(lp)
+                        - MarginLayoutParamsCompat.getMarginEnd(lp)) / 2;
                 if (!isRtl) {
-                    view.layout(left + leftFromCrossAxis + lp.leftMargin - lp.rightMargin,
-                            top, right + leftFromCrossAxis + lp.leftMargin - lp.rightMargin,
-                            bottom);
+                    view.layout(left + leftFromCrossAxis, top, right + leftFromCrossAxis, bottom);
                 } else {
-                    view.layout(left - leftFromCrossAxis + lp.leftMargin - lp.rightMargin,
-                            top, right - leftFromCrossAxis + lp.leftMargin - lp.rightMargin,
-                            bottom);
+                    view.layout(left - leftFromCrossAxis, top, right - leftFromCrossAxis, bottom);
                 }
                 break;
         }


### PR DESCRIPTION
- AlignItems (or AlignSelf) is set to center
- Margin is set to only one side for a flex item. E.g. Margin is only put only right when flexDirection is column

Fixes #138 
