### PR TITLE
Add support for the flex grow attribute for the FlexboxLayoutManager.

### DIFF
--- a/app/src/main/java/com/google/android/flexbox/RecyclerViewFragment.java
+++ b/app/src/main/java/com/google/android/flexbox/RecyclerViewFragment.java
@@ -65,10 +65,10 @@ public class RecyclerViewFragment extends Fragment {
             addFab.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {
-                    RecyclerView.LayoutParams lp = new FlexboxLayoutManager.LayoutParams(
+                    FlexboxLayoutManager.LayoutParams lp = new FlexboxLayoutManager.LayoutParams(
                             ViewGroup.LayoutParams.WRAP_CONTENT,
                             ViewGroup.LayoutParams.WRAP_CONTENT);
-                    fragmentHelper.setFlexItemAttributes((FlexItem) lp);
+                    fragmentHelper.setFlexItemAttributes(lp);
                     adapter.addItem(lp);
                     // TODO: Specify index?
                     adapter.notifyDataSetChanged();

--- a/app/src/main/java/com/google/android/flexbox/recyclerview/FlexItemAdapter.java
+++ b/app/src/main/java/com/google/android/flexbox/recyclerview/FlexItemAdapter.java
@@ -54,7 +54,7 @@ public class FlexItemAdapter extends RecyclerView.Adapter<FlexItemViewHolder> {
         holder.mTextView.setText(String.valueOf(position + 1));
         holder.mTextView.setBackgroundResource(R.drawable.flex_item_background);
         holder.mTextView.setGravity(Gravity.CENTER);
-        holder.mItemView.setLayoutParams(mLayoutParams.get(position));
+        holder.mTextView.setLayoutParams(mLayoutParams.get(position));
     }
 
     public void addItem(RecyclerView.LayoutParams lp) {

--- a/app/src/main/java/com/google/android/flexbox/recyclerview/FlexItemViewHolder.java
+++ b/app/src/main/java/com/google/android/flexbox/recyclerview/FlexItemViewHolder.java
@@ -28,12 +28,10 @@ import android.widget.TextView;
 public class FlexItemViewHolder extends RecyclerView.ViewHolder {
 
     TextView mTextView;
-    View mItemView;
 
     public FlexItemViewHolder(View itemView) {
         super(itemView);
 
-        mItemView = itemView;
         mTextView = (TextView) itemView.findViewById(R.id.textview);
     }
 }

--- a/app/src/main/res/layout/viewholder_flex_item.xml
+++ b/app/src/main/res/layout/viewholder_flex_item.xml
@@ -13,12 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
-
-    <TextView
-        android:id="@+id/textview"
-        android:layout_width="@dimen/flex_item_length2"
-        android:layout_height="@dimen/flex_item_length" />
-</FrameLayout>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/textview"
+    android:layout_width="@dimen/flex_item_length2"
+    android:layout_height="@dimen/flex_item_length" />

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/FlexboxHelperTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/FlexboxHelperTest.java
@@ -164,8 +164,7 @@ public class FlexboxHelperTest {
         FlexboxHelper.FlexLinesResult result = mFlexboxHelper
                 .calculateHorizontalFlexLines(widthMeasureSpec, heightMeasureSpec);
         mFlexContainer.setFlexLines(result.mFlexLines);
-        boolean[] childrenFrozen = new boolean[4];
-        mFlexboxHelper.determineMainSize(widthMeasureSpec, heightMeasureSpec, childrenFrozen);
+        mFlexboxHelper.determineMainSize(widthMeasureSpec, heightMeasureSpec);
 
         assertThat(view1.getMeasuredWidth(), is(100));
         assertThat(view1.getMeasuredHeight(), is(100));
@@ -208,8 +207,7 @@ public class FlexboxHelperTest {
         FlexboxHelper.FlexLinesResult result = mFlexboxHelper
                 .calculateVerticalFlexLines(widthMeasureSpec, heightMeasureSpec);
         mFlexContainer.setFlexLines(result.mFlexLines);
-        boolean[] childrenFrozen = new boolean[4];
-        mFlexboxHelper.determineMainSize(widthMeasureSpec, heightMeasureSpec, childrenFrozen);
+        mFlexboxHelper.determineMainSize(widthMeasureSpec, heightMeasureSpec);
 
         assertThat(view1.getMeasuredWidth(), is(100));
         assertThat(view1.getMeasuredHeight(), is(100));
@@ -250,8 +248,7 @@ public class FlexboxHelperTest {
         FlexboxHelper.FlexLinesResult result = mFlexboxHelper
                 .calculateHorizontalFlexLines(widthMeasureSpec, heightMeasureSpec);
         mFlexContainer.setFlexLines(result.mFlexLines);
-        boolean[] childrenFrozen = new boolean[4];
-        mFlexboxHelper.determineMainSize(widthMeasureSpec, heightMeasureSpec, childrenFrozen);
+        mFlexboxHelper.determineMainSize(widthMeasureSpec, heightMeasureSpec);
 
         // Flex shrink is set to 1.0 (default value) for all views.
         // They should be shrank equally for the amount overflown the width
@@ -292,8 +289,7 @@ public class FlexboxHelperTest {
         FlexboxHelper.FlexLinesResult result = mFlexboxHelper
                 .calculateVerticalFlexLines(widthMeasureSpec, heightMeasureSpec);
         mFlexContainer.setFlexLines(result.mFlexLines);
-        boolean[] childrenFrozen = new boolean[4];
-        mFlexboxHelper.determineMainSize(widthMeasureSpec, heightMeasureSpec, childrenFrozen);
+        mFlexboxHelper.determineMainSize(widthMeasureSpec, heightMeasureSpec);
 
         // Flex shrink is set to 1.0 (default value) for all views.
         // They should be shrank equally for the amount overflown the height
@@ -335,8 +331,7 @@ public class FlexboxHelperTest {
         FlexboxHelper.FlexLinesResult result = mFlexboxHelper
                 .calculateHorizontalFlexLines(widthMeasureSpec, heightMeasureSpec);
         mFlexContainer.setFlexLines(result.mFlexLines);
-        boolean[] childrenFrozen = new boolean[4];
-        mFlexboxHelper.determineMainSize(widthMeasureSpec, heightMeasureSpec, childrenFrozen);
+        mFlexboxHelper.determineMainSize(widthMeasureSpec, heightMeasureSpec);
         mFlexboxHelper
                 .determineCrossSize(widthMeasureSpec, heightMeasureSpec, 0);
         mFlexboxHelper.stretchViews();
@@ -378,8 +373,7 @@ public class FlexboxHelperTest {
         FlexboxHelper.FlexLinesResult result = mFlexboxHelper
                 .calculateVerticalFlexLines(widthMeasureSpec, heightMeasureSpec);
         mFlexContainer.setFlexLines(result.mFlexLines);
-        boolean[] childrenFrozen = new boolean[4];
-        mFlexboxHelper.determineMainSize(widthMeasureSpec, heightMeasureSpec, childrenFrozen);
+        mFlexboxHelper.determineMainSize(widthMeasureSpec, heightMeasureSpec);
         mFlexboxHelper
                 .determineCrossSize(widthMeasureSpec, heightMeasureSpec, 0);
         mFlexboxHelper.stretchViews();

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
@@ -35,6 +35,7 @@ import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.support.v7.widget.RecyclerView;
 
+import static com.google.android.flexbox.test.IsEqualAllowingError.isEqualAllowingError;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -191,15 +192,55 @@ public class FlexboxLayoutManagerTest {
         assertThat(layoutManager.getFlexLines().size(), is(5));
     }
 
+    @Test
+    @FlakyTest
+    public void testFlexGrow() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final TestAdapter adapter = new TestAdapter();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.recyclerview);
+                RecyclerView recyclerView = (RecyclerView) activity.findViewById(R.id.recyclerview);
+                recyclerView.setLayoutManager(layoutManager);
+                recyclerView.setAdapter(adapter);
+                FlexboxLayoutManager.LayoutParams lp1 = createLayoutParams(activity, 150, 130);
+                lp1.setFlexGrow(1.0f);
+                adapter.addItem(lp1);
+                FlexboxLayoutManager.LayoutParams lp2 = createLayoutParams(activity, 150, 130);
+                lp2.setFlexGrow(1.0f);
+                adapter.addItem(lp2);
+                FlexboxLayoutManager.LayoutParams lp3 = createLayoutParams(activity, 150, 130);
+                lp3.setFlexGrow(1.0f);
+                adapter.addItem(lp3);
+                // RecyclerView width: 400, height: 300.
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // The flexGrow parameters for all LayoutParams are set to 1.0, expecting each child to
+        // fill the horizontal remaining space
+        assertThat(layoutManager.getFlexItemCount(), is(3));
+        assertThat(layoutManager.getFlexLines().size(), is(2));
+        assertThat(layoutManager.getChildAt(0).getWidth(),
+                isEqualAllowingError(TestUtil.dpToPixel(activity, 200)));
+        assertThat(layoutManager.getChildAt(1).getWidth(),
+                isEqualAllowingError(TestUtil.dpToPixel(activity, 200)));
+        assertThat(layoutManager.getChildAt(2).getWidth(),
+                isEqualAllowingError(TestUtil.dpToPixel(activity, 400)));
+    }
+
     /**
      * Creates a new flex item.
      *
      * @param context the context
      * @param width   in DP
      * @param height  in DP
-     * @return the created {@link RecyclerView.LayoutParams} instance
+     * @return the created {@link FlexboxLayoutManager.LayoutParams} instance
      */
-    private RecyclerView.LayoutParams createLayoutParams(Context context, int width, int height) {
+    private FlexboxLayoutManager.LayoutParams createLayoutParams(Context context, int width,
+            int height) {
         return new FlexboxLayoutManager.LayoutParams(
                 TestUtil.dpToPixel(context, width),
                 TestUtil.dpToPixel(context, height));

--- a/flexbox/src/androidTest/res/layout/recyclerview_viewholder.xml
+++ b/flexbox/src/androidTest/res/layout/recyclerview_viewholder.xml
@@ -13,12 +13,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
 
-    <TextView
-        android:id="@+id/textview"
-        android:layout_width="120dp"
-        android:layout_height="80dp" />
-</FrameLayout>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/textview"
+    android:layout_width="120dp"
+    android:layout_height="80dp" />

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
@@ -79,10 +79,8 @@ class FlexboxHelper {
     SparseIntArray mIndexToFlexLine;
 
     /**
-     * Cache the measured spec. The first 32 bit of represents the height measure spec, the last
+     * Cache the measured spec. The first 32 bit represents the height measure spec, the last
      * 32 bit represents the width measure spec of each flex item.
-     * The first 32 bit consists of the height measure spec and the last 32 bit consists of the
-     * width measure spec.
      * E.g. an entry is created like {@code (long) heightMeasureSpec << 32 | widthMeasureSpec}
      */
     @Nullable
@@ -603,7 +601,8 @@ class FlexboxHelper {
         if (mChildrenFrozen == null) {
             mChildrenFrozen = new boolean[size < INITIAL_CAPACITY ? INITIAL_CAPACITY : size];
         } else if (mChildrenFrozen.length < size) {
-            mChildrenFrozen = new boolean[mChildrenFrozen.length * 2];
+            int newCapacity = mChildrenFrozen.length * 2;
+            mChildrenFrozen = new boolean[newCapacity >= size ? newCapacity : size];
         } else {
             Arrays.fill(mChildrenFrozen, false);
         }
@@ -1234,7 +1233,8 @@ class FlexboxHelper {
         if (mMeasureSpecCache == null) {
             mMeasureSpecCache = new long[size < INITIAL_CAPACITY ? INITIAL_CAPACITY : size];
         } else if (mMeasureSpecCache.length < size) {
-            mMeasureSpecCache = new long[mMeasureSpecCache.length * 2];
+            int newCapacity = mMeasureSpecCache.length * 2;
+            mMeasureSpecCache = new long[newCapacity >= size ? newCapacity : size];
         }
     }
 

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
@@ -17,12 +17,14 @@
 package com.google.android.flexbox;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.view.ViewCompat;
 import android.util.SparseIntArray;
 import android.view.View;
 import android.view.ViewGroup;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -31,6 +33,10 @@ import java.util.List;
  * {@link FlexboxLayout} and {@link FlexboxLayoutManager}.
  */
 class FlexboxHelper {
+
+    private static final int INITIAL_CAPACITY = 10;
+
+    private static final long MEASURE_SPEC_WIDTH_MASK = 0xffffffffL;
 
     private final FlexContainer mFlexContainer;
 
@@ -49,6 +55,12 @@ class FlexboxHelper {
     private SparseIntArray mOrderCache;
 
     /**
+     * Holds the 'frozen' state of children during measure. If a view is frozen it will no longer
+     * expand or shrink regardless of flex grow/flex shrink attributes.
+     */
+    private boolean[] mChildrenFrozen;
+
+    /**
      * Map the view index to the flex line which contains the view represented by the index to
      * look for a flex line from a given view index in a constant time.
      * Key: index of the view
@@ -65,6 +77,16 @@ class FlexboxHelper {
      * </p>
      */
     SparseIntArray mIndexToFlexLine;
+
+    /**
+     * Cache the measured spec. The first 32 bit of represents the height measure spec, the last
+     * 32 bit represents the width measure spec of each flex item.
+     * The first 32 bit consists of the height measure spec and the last 32 bit consists of the
+     * width measure spec.
+     * E.g. an entry is created like {@code (long) heightMeasureSpec << 32 | widthMeasureSpec}
+     */
+    @Nullable
+    long[] mMeasureSpecCache;
 
     FlexboxHelper(FlexContainer flexContainer) {
         mFlexContainer = flexContainer;
@@ -250,6 +272,11 @@ class FlexboxHelper {
                                     + flexItem.getMarginTop()
                                     + flexItem.getMarginBottom(), flexItem.getHeight());
             child.measure(childWidthMeasureSpec, childHeightMeasureSpec);
+            if (mMeasureSpecCache != null) {
+                mMeasureSpecCache[i] = makeCombinedMeasureSpec(
+                        childWidthMeasureSpec,
+                        childHeightMeasureSpec);
+            }
 
             // Check the size constraint after the first measurement for the child
             // To prevent the child's width/height violate the size constraints imposed by the
@@ -257,7 +284,7 @@ class FlexboxHelper {
             // {@link FlexItem#getMaxWidth()} and {@link FlexItem#getMaxHeight()} attributes.
             // E.g. When the child's layout_width is wrap_content the measured width may be
             // less than the min width after the first measurement.
-            checkSizeConstraints(child);
+            checkSizeConstraints(child, i);
 
             childState = ViewCompat
                     .combineMeasuredStates(childState, ViewCompat.getMeasuredState(child));
@@ -374,6 +401,11 @@ class FlexboxHelper {
                             mFlexContainer.getPaddingTop() + mFlexContainer.getPaddingBottom()
                                     + lp.topMargin + lp.bottomMargin, childHeight);
             child.measure(childWidthMeasureSpec, childHeightMeasureSpec);
+            if (mMeasureSpecCache != null) {
+                mMeasureSpecCache[i] = makeCombinedMeasureSpec(
+                        childWidthMeasureSpec,
+                        childHeightMeasureSpec);
+            }
 
             // Check the size constraint after the first measurement for the child
             // To prevent the child's width/height violate the size constraints imposed by the
@@ -381,7 +413,7 @@ class FlexboxHelper {
             // {@link LayoutParams#mMaxWidth} and {@link LayoutParams#mMaxHeight} attributes.
             // E.g. When the child's layout_height is wrap_content the measured height may be
             // less than the min height after the first measurement.
-            checkSizeConstraints(child);
+            checkSizeConstraints(child, i);
 
             childState = ViewCompat
                     .combineMeasuredStates(childState, ViewCompat.getMeasuredState(child));
@@ -475,9 +507,10 @@ class FlexboxHelper {
      * by the {@link FlexItem#getMinWidth()}, {@link FlexItem#getMinHeight()},
      * {@link FlexItem#getMaxWidth()} and {@link FlexItem#getMaxHeight()} attributes.
      *
-     * @param view the view to be checked
+     * @param view  the view to be checked
+     * @param index index of the view
      */
-    private void checkSizeConstraints(View view) {
+    private void checkSizeConstraints(View view, int index) {
         boolean needsMeasure = false;
         FlexItem flexItem = (FlexItem) view.getLayoutParams();
         int childWidth = view.getMeasuredWidth();
@@ -499,8 +532,13 @@ class FlexboxHelper {
             childHeight = flexItem.getMaxHeight();
         }
         if (needsMeasure) {
-            view.measure(View.MeasureSpec.makeMeasureSpec(childWidth, View.MeasureSpec.EXACTLY),
-                    View.MeasureSpec.makeMeasureSpec(childHeight, View.MeasureSpec.EXACTLY));
+            int widthSpec = View.MeasureSpec.makeMeasureSpec(childWidth, View.MeasureSpec.EXACTLY);
+            int heightSpec = View.MeasureSpec
+                    .makeMeasureSpec(childHeight, View.MeasureSpec.EXACTLY);
+            view.measure(widthSpec, heightSpec);
+            if (mMeasureSpecCache != null) {
+                mMeasureSpecCache[index] = makeCombinedMeasureSpec(widthSpec, heightSpec);
+            }
         }
     }
 
@@ -512,14 +550,11 @@ class FlexboxHelper {
      *
      * @param widthMeasureSpec  horizontal space requirements as imposed by the parent
      * @param heightMeasureSpec vertical space requirements as imposed by the parent
-     * @param childrenFrozen    a boolean array that represents 'frozen' state of children during
-     *                          measure. If a view is frozen it will no longer
-     *                          expand or shrink regardless of flex grow/flex shrink attributes.
-     *                          Items are indexed by the child's reordered index.
      * @see FlexContainer#setFlexDirection(int)
      * @see FlexContainer#getFlexDirection()
      */
-    void determineMainSize(int widthMeasureSpec, int heightMeasureSpec, boolean[] childrenFrozen) {
+    void determineMainSize(int widthMeasureSpec, int heightMeasureSpec) {
+        ensureChildrenFrozen(mFlexContainer.getFlexItemCount());
         int mainSize;
         int paddingAlongMainAxis;
         int flexDirection = mFlexContainer.getFlexDirection();
@@ -556,11 +591,21 @@ class FlexboxHelper {
         for (FlexLine flexLine : mFlexContainer.getFlexLinesInternal()) {
             if (flexLine.mMainSize < mainSize) {
                 childIndex = expandFlexItems(widthMeasureSpec, heightMeasureSpec, flexLine,
-                        mainSize, paddingAlongMainAxis, childIndex, childrenFrozen);
+                        mainSize, paddingAlongMainAxis, childIndex);
             } else {
                 childIndex = shrinkFlexItems(widthMeasureSpec, heightMeasureSpec, flexLine,
-                        mainSize, paddingAlongMainAxis, childIndex, childrenFrozen);
+                        mainSize, paddingAlongMainAxis, childIndex);
             }
+        }
+    }
+
+    private void ensureChildrenFrozen(int size) {
+        if (mChildrenFrozen == null) {
+            mChildrenFrozen = new boolean[size < INITIAL_CAPACITY ? INITIAL_CAPACITY : size];
+        } else if (mChildrenFrozen.length < size) {
+            mChildrenFrozen = new boolean[mChildrenFrozen.length * 2];
+        } else {
+            Arrays.fill(mChildrenFrozen, false);
         }
     }
 
@@ -582,7 +627,7 @@ class FlexboxHelper {
      * @see FlexItem#getFlexGrow()
      */
     private int expandFlexItems(int widthMeasureSpec, int heightMeasureSpec, FlexLine flexLine,
-            int maxMainSize, int paddingAlongMainAxis, int startIndex, boolean[] childrenFrozen) {
+            int maxMainSize, int paddingAlongMainAxis, int startIndex) {
         int childIndex = startIndex;
         if (flexLine.mTotalFlexGrow <= 0 || maxMainSize < flexLine.mMainSize) {
             childIndex += flexLine.mItemCount;
@@ -616,8 +661,19 @@ class FlexboxHelper {
             int flexDirection = mFlexContainer.getFlexDirection();
             if (flexDirection == FlexDirection.ROW || flexDirection == FlexDirection.ROW_REVERSE) {
                 // The direction of the main axis is horizontal
-                if (!childrenFrozen[childIndex]) {
-                    float rawCalculatedWidth = child.getMeasuredWidth()
+                if (!mChildrenFrozen[childIndex] && flexItem.getFlexGrow() > 0f) {
+
+                    int childMeasuredWidth = child.getMeasuredWidth();
+                    if (mMeasureSpecCache != null) {
+                        // Retrieve the measured width from the measure spec cache because there
+                        // are some cases that the view is re-created from the last measure, thus
+                        // View#getMeasuredWidth returns 0.
+                        // E.g. if the flex container is FlexboxLayoutManager, the case happens
+                        // frequently
+                        int childWidthSpec = extractWidthMeasureSpec(mMeasureSpecCache[childIndex]);
+                        childMeasuredWidth = View.MeasureSpec.getSize(childWidthSpec);
+                    }
+                    float rawCalculatedWidth = childMeasuredWidth
                             + unitSpace * flexItem.getFlexGrow();
                     if (i == flexLine.mItemCount - 1) {
                         rawCalculatedWidth += accumulatedRoundError;
@@ -632,7 +688,7 @@ class FlexboxHelper {
                         // startIndex.
                         needsReexpand = true;
                         newWidth = flexItem.getMaxWidth();
-                        childrenFrozen[childIndex] = true;
+                        mChildrenFrozen[childIndex] = true;
                         flexLine.mTotalFlexGrow -= flexItem.getFlexGrow();
                     } else {
                         accumulatedRoundError += (rawCalculatedWidth - newWidth);
@@ -646,17 +702,33 @@ class FlexboxHelper {
                     }
                     int childHeightMeasureSpec = getChildHeightMeasureSpecInternal(
                             heightMeasureSpec, flexItem);
-                    child.measure(
-                            View.MeasureSpec.makeMeasureSpec(newWidth, View.MeasureSpec.EXACTLY),
-                            childHeightMeasureSpec);
+                    int childWidthMeasureSpec = View.MeasureSpec.makeMeasureSpec(newWidth,
+                            View.MeasureSpec.EXACTLY);
+                    child.measure(childWidthMeasureSpec, childHeightMeasureSpec);
+                    if (mMeasureSpecCache != null) {
+                        mMeasureSpecCache[childIndex] = makeCombinedMeasureSpec(
+                                childWidthMeasureSpec,
+                                childHeightMeasureSpec);
+                    }
                 }
                 flexLine.mMainSize += child.getMeasuredWidth() + flexItem.getMarginLeft()
                         + flexItem.getMarginRight();
                 flexLine.mCrossSize = Math.max(flexLine.mCrossSize, child.getMeasuredHeight());
             } else {
                 // The direction of the main axis is vertical
-                if (!childrenFrozen[childIndex]) {
-                    float rawCalculatedHeight = child.getMeasuredHeight()
+                if (!mChildrenFrozen[childIndex] && flexItem.getFlexGrow() > 0f) {
+                    int childMeasuredHeight = child.getMeasuredHeight();
+                    if (mMeasureSpecCache != null) {
+                        // Retrieve the measured height from the measure spec cache because there
+                        // are some cases that the view is re-created from the last measure, thus
+                        // View#getMeasuredHeight returns 0.
+                        // E.g. if the flex container is FlexboxLayoutManager, that case happens
+                        // frequently
+                        int childHeightSpec =
+                                extractHeightMeasureSpec(mMeasureSpecCache[childIndex]);
+                        childMeasuredHeight = View.MeasureSpec.getSize(childHeightSpec);
+                    }
+                    float rawCalculatedHeight = childMeasuredHeight
                             + unitSpace * flexItem.getFlexGrow();
                     if (i == flexLine.mItemCount - 1) {
                         rawCalculatedHeight += accumulatedRoundError;
@@ -672,7 +744,7 @@ class FlexboxHelper {
                         // startIndex.
                         needsReexpand = true;
                         newHeight = flexItem.getMaxHeight();
-                        childrenFrozen[childIndex] = true;
+                        mChildrenFrozen[childIndex] = true;
                         flexLine.mTotalFlexGrow -= flexItem.getFlexGrow();
                     } else {
                         accumulatedRoundError += (rawCalculatedHeight - newHeight);
@@ -686,8 +758,14 @@ class FlexboxHelper {
                     }
                     int childWidthMeasureSpec = getChildWidthMeasureSpecInternal(widthMeasureSpec,
                             flexItem);
-                    child.measure(childWidthMeasureSpec,
-                            View.MeasureSpec.makeMeasureSpec(newHeight, View.MeasureSpec.EXACTLY));
+                    int childHeightMeasureSpec = View.MeasureSpec.makeMeasureSpec(newHeight,
+                            View.MeasureSpec.EXACTLY);
+                    child.measure(childWidthMeasureSpec, childHeightMeasureSpec);
+                    if (mMeasureSpecCache != null) {
+                        mMeasureSpecCache[childIndex] = makeCombinedMeasureSpec(
+                                childWidthMeasureSpec,
+                                childHeightMeasureSpec);
+                    }
                 }
                 flexLine.mMainSize += child.getMeasuredHeight() + flexItem.getMarginTop()
                         + flexItem.getMarginBottom();
@@ -700,7 +778,7 @@ class FlexboxHelper {
             // Re-invoke the method with the same startIndex to distribute the positive free space
             // that wasn't fully distributed (because of maximum length constraint)
             expandFlexItems(widthMeasureSpec, heightMeasureSpec, flexLine, maxMainSize,
-                    paddingAlongMainAxis, startIndex, childrenFrozen);
+                    paddingAlongMainAxis, startIndex);
         }
         return childIndex;
     }
@@ -723,7 +801,7 @@ class FlexboxHelper {
      * @see FlexItem#getFlexShrink()
      */
     private int shrinkFlexItems(int widthMeasureSpec, int heightMeasureSpec, FlexLine flexLine,
-            int maxMainSize, int paddingAlongMainAxis, int startIndex, boolean[] childrenFrozen) {
+            int maxMainSize, int paddingAlongMainAxis, int startIndex) {
         int childIndex = startIndex;
         int sizeBeforeShrink = flexLine.mMainSize;
         if (flexLine.mTotalFlexShrink <= 0 || maxMainSize > flexLine.mMainSize) {
@@ -757,8 +835,18 @@ class FlexboxHelper {
             int flexDirection = mFlexContainer.getFlexDirection();
             if (flexDirection == FlexDirection.ROW || flexDirection == FlexDirection.ROW_REVERSE) {
                 // The direction of main axis is horizontal
-                if (!childrenFrozen[childIndex]) {
-                    float rawCalculatedWidth = child.getMeasuredWidth()
+                if (!mChildrenFrozen[childIndex] && flexItem.getFlexShrink() > 0f) {
+                    int childMeasuredWidth = child.getMeasuredWidth();
+                    if (mMeasureSpecCache != null) {
+                        // Retrieve the measured width from the measure spec cache because there
+                        // are some cases that the view is re-created from the last measure, thus
+                        // View#getMeasuredWidth returns 0.
+                        // E.g. if the flex container is FlexboxLayoutManager, that case happens
+                        // frequently
+                        int childWidthSpec = extractWidthMeasureSpec(mMeasureSpecCache[childIndex]);
+                        childMeasuredWidth = View.MeasureSpec.getSize(childWidthSpec);
+                    }
+                    float rawCalculatedWidth = childMeasuredWidth
                             - unitShrink * flexItem.getFlexShrink();
                     if (i == flexLine.mItemCount - 1) {
                         rawCalculatedWidth += accumulatedRoundError;
@@ -773,7 +861,7 @@ class FlexboxHelper {
                         // startIndex.
                         needsReshrink = true;
                         newWidth = flexItem.getMinWidth();
-                        childrenFrozen[childIndex] = true;
+                        mChildrenFrozen[childIndex] = true;
                         flexLine.mTotalFlexShrink -= flexItem.getFlexShrink();
                     } else {
                         accumulatedRoundError += (rawCalculatedWidth - newWidth);
@@ -787,17 +875,33 @@ class FlexboxHelper {
                     }
                     int childHeightMeasureSpec = getChildHeightMeasureSpecInternal(
                             heightMeasureSpec, flexItem);
-                    child.measure(
-                            View.MeasureSpec.makeMeasureSpec(newWidth, View.MeasureSpec.EXACTLY),
-                            childHeightMeasureSpec);
+                    int childWidthMeasureSpec =
+                            View.MeasureSpec.makeMeasureSpec(newWidth, View.MeasureSpec.EXACTLY);
+                    child.measure(childWidthMeasureSpec, childHeightMeasureSpec);
+                    if (mMeasureSpecCache != null) {
+                        mMeasureSpecCache[childIndex] = makeCombinedMeasureSpec(
+                                childWidthMeasureSpec,
+                                childHeightMeasureSpec);
+                    }
                 }
                 flexLine.mMainSize += child.getMeasuredWidth() + flexItem.getMarginLeft()
                         + flexItem.getMarginRight();
                 flexLine.mCrossSize = Math.max(flexLine.mCrossSize, child.getMeasuredHeight());
             } else {
                 // The direction of main axis is vertical
-                if (!childrenFrozen[childIndex]) {
-                    float rawCalculatedHeight = child.getMeasuredHeight()
+                if (!mChildrenFrozen[childIndex] && flexItem.getFlexShrink() > 0f) {
+                    int childMeasuredHeight = child.getMeasuredHeight();
+                    if (mMeasureSpecCache != null) {
+                        // Retrieve the measured height from the measure spec cache because there
+                        // are some cases that the view is re-created from the last measure, thus
+                        // View#getMeasuredHeight returns 0.
+                        // E.g. if the flex container is FlexboxLayoutManager, the case happens
+                        // frequently
+                        int childHeightSpec =
+                                extractHeightMeasureSpec(mMeasureSpecCache[childIndex]);
+                        childMeasuredHeight = View.MeasureSpec.getSize(childHeightSpec);
+                    }
+                    float rawCalculatedHeight = childMeasuredHeight
                             - unitShrink * flexItem.getFlexShrink();
                     if (i == flexLine.mItemCount - 1) {
                         rawCalculatedHeight += accumulatedRoundError;
@@ -808,7 +912,7 @@ class FlexboxHelper {
                         // Need to invoke this method again like the case flex direction is vertical
                         needsReshrink = true;
                         newHeight = flexItem.getMinHeight();
-                        childrenFrozen[childIndex] = true;
+                        mChildrenFrozen[childIndex] = true;
                         flexLine.mTotalFlexShrink -= flexItem.getFlexShrink();
                     } else {
                         accumulatedRoundError += (rawCalculatedHeight - newHeight);
@@ -822,8 +926,14 @@ class FlexboxHelper {
                     }
                     int childWidthMeasureSpec = getChildWidthMeasureSpecInternal(widthMeasureSpec,
                             flexItem);
-                    child.measure(childWidthMeasureSpec,
-                            View.MeasureSpec.makeMeasureSpec(newHeight, View.MeasureSpec.EXACTLY));
+                    int childHeightMeasureSpec =
+                            View.MeasureSpec.makeMeasureSpec(newHeight, View.MeasureSpec.EXACTLY);
+                    child.measure(childWidthMeasureSpec, childHeightMeasureSpec);
+                    if (mMeasureSpecCache != null) {
+                        mMeasureSpecCache[childIndex] = makeCombinedMeasureSpec(
+                                childWidthMeasureSpec,
+                                childHeightMeasureSpec);
+                    }
                 }
                 flexLine.mMainSize += child.getMeasuredHeight() + flexItem.getMarginTop()
                         + flexItem.getMarginBottom();
@@ -836,7 +946,7 @@ class FlexboxHelper {
             // Re-invoke the method with the same startIndex to distribute the negative free space
             // that wasn't fully distributed (because some views length were not enough)
             shrinkFlexItems(widthMeasureSpec, heightMeasureSpec, flexLine,
-                    maxMainSize, paddingAlongMainAxis, startIndex, childrenFrozen);
+                    maxMainSize, paddingAlongMainAxis, startIndex);
         }
         return childIndex;
     }
@@ -1118,6 +1228,47 @@ class FlexboxHelper {
                         .makeMeasureSpec(newWidth, View.MeasureSpec.EXACTLY),
                 View.MeasureSpec
                         .makeMeasureSpec(view.getMeasuredHeight(), View.MeasureSpec.EXACTLY));
+    }
+
+    void ensureMeasureSpecCache(int size) {
+        if (mMeasureSpecCache == null) {
+            mMeasureSpecCache = new long[size < INITIAL_CAPACITY ? INITIAL_CAPACITY : size];
+        } else if (mMeasureSpecCache.length < size) {
+            mMeasureSpecCache = new long[mMeasureSpecCache.length * 2];
+        }
+    }
+
+    /**
+     * @param measureSpec the long value that consists of width and height measure specs
+     * @return the width measure spec from the combined long value
+     * @see #makeCombinedMeasureSpec(int, int)
+     */
+    int extractWidthMeasureSpec(long measureSpec) {
+        return (int) (measureSpec & MEASURE_SPEC_WIDTH_MASK);
+    }
+
+    /**
+     * @param measureSpec the long value that consists of width and height measure specs
+     * @return the height measure spec from the combined long value
+     * @see #makeCombinedMeasureSpec(int, int)
+     */
+    int extractHeightMeasureSpec(long measureSpec) {
+        return (int) (measureSpec >> 32);
+    }
+
+    /**
+     * Make a long value from the a width measure spec and a height measure spec.
+     * The first 32 bit is used for the height measure spec and the last 32 bit is used for the
+     * width measure spec.
+     *
+     * @param widthMeasureSpec  the width measure spec to consist the result long value
+     * @param heightMeasureSpec the height measure spec to consist the result long value
+     * @return the combined long value
+     * @see #extractWidthMeasureSpec(long)
+     * @see #extractHeightMeasureSpec(long)
+     */
+    private long makeCombinedMeasureSpec(int widthMeasureSpec, int heightMeasureSpec) {
+        return (long) heightMeasureSpec << 32 | widthMeasureSpec;
     }
 
     /**

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
@@ -245,10 +245,6 @@ public class FlexboxLayout extends ViewGroup implements FlexContainer {
         if (mFlexboxHelper.isOrderChangedFromLastMeasurement()) {
             mFlexboxHelper.mReorderedIndices = mFlexboxHelper.createReorderedIndices();
         }
-        if (mChildrenFrozen == null
-                || mChildrenFrozen.length < getChildCount()) {
-            mChildrenFrozen = new boolean[getChildCount()];
-        }
 
         // TODO: Only calculate the children views which are affected from the last measure.
 
@@ -265,8 +261,6 @@ public class FlexboxLayout extends ViewGroup implements FlexContainer {
                 throw new IllegalStateException(
                         "Invalid value for the flex direction is set: " + mFlexDirection);
         }
-
-        Arrays.fill(mChildrenFrozen, false);
     }
 
     @Override
@@ -329,7 +323,7 @@ public class FlexboxLayout extends ViewGroup implements FlexContainer {
                 .calculateHorizontalFlexLines(widthMeasureSpec, heightMeasureSpec);
         mFlexLines = flexLinesResult.mFlexLines;
 
-        mFlexboxHelper.determineMainSize(widthMeasureSpec, heightMeasureSpec, mChildrenFrozen);
+        mFlexboxHelper.determineMainSize(widthMeasureSpec, heightMeasureSpec);
 
         // TODO: Consider the case any individual child's mAlignSelf is set to ALIGN_SELF_BASELINE
         if (mAlignItems == AlignItems.BASELINE) {
@@ -385,8 +379,7 @@ public class FlexboxLayout extends ViewGroup implements FlexContainer {
                 .calculateVerticalFlexLines(widthMeasureSpec, heightMeasureSpec);
         mFlexLines = flexLinesResult.mFlexLines;
 
-        mFlexboxHelper.determineMainSize(widthMeasureSpec, heightMeasureSpec,
-                mChildrenFrozen);
+        mFlexboxHelper.determineMainSize(widthMeasureSpec, heightMeasureSpec);
         mFlexboxHelper.determineCrossSize(widthMeasureSpec, heightMeasureSpec,
                 getPaddingLeft() + getPaddingRight());
         // Now cross size for each flex line is determined.


### PR DESCRIPTION
This CL introduces a cache for measured width/height measure specs.
Because during the layout phase of the FlexboxLayoutManager,
a view retrieved from the Recycler may be re-created from the last maesure,
making the measured width/height set to 0 even if each child is at least
measured once in the FlexboxHelper.
So when the flex container is the FlexboxLayoutManager, the FlexboxHelper
stores each measured width/height specs in the cache  and the specs from the cache
is used where it's required.
