### PR TITLE
Fix the issue that child margins do not expand flexbox container with wrap_content

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
@@ -3835,6 +3835,130 @@ public class FlexboxAndroidTest {
                 isEqualAllowingError(TestUtil.dpToPixel(activity, 50)));
     }
 
+    @Test
+    @FlakyTest
+    public void testChildBottomMarginIncluded_flexContainerWrapContent_directionRow_flexGrow()
+            throws Throwable {
+        // This test is to verify the case where:
+        //   - layout_height is set to wrap_content for the FlexboxLayout
+        //   - Bottom (or top) margin is set to a child
+        //   - The child which the has the bottom (top) margin has the largest height in the
+        //     same flex line (or only a single child exists)
+        //   - The child has a positive layout_flexGrow attribute set
+        //  If these conditions were met, the height of the FlexboxLayout didn't take the bottom
+        //  margin on the child into account
+        //  See https://github.com/google/flexbox-layout/issues/154
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(
+                        R.layout.activity_wrap_content_child_bottom_margin_row_grow);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        // layout_height for text1: 24dp, layout_marginBottom: 12dp
+        assertThat(flexboxLayout.getHeight(),
+                isEqualAllowingError(TestUtil.dpToPixel(activity, 36)));
+    }
+
+    @Test
+    @FlakyTest
+    public void testChildEndMarginIncluded_flexContainerWrapContent_directionColumn_flexGrow()
+            throws Throwable {
+        // This test is to verify the case where:
+        //   - layout_width is set to wrap_content for the FlexboxLayout
+        //   - End (or start) margin is set to a child
+        //   - The child which the has the end (start) margin has the largest width in the
+        //     same flex line (or only a single child exists)
+        //   - The child has a positive layout_flexGrow attribute set
+        //  If these conditions were met, the width of the FlexboxLayout didn't take the bottom
+        //  margin on the child into account
+        //  See https://github.com/google/flexbox-layout/issues/154
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(
+                        R.layout.activity_wrap_content_child_bottom_margin_column_grow);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        // layout_width for text1: 24dp, layout_marginEnd: 12dp
+        assertThat(flexboxLayout.getWidth(),
+                isEqualAllowingError(TestUtil.dpToPixel(activity, 36)));
+    }
+
+    @Test
+    @FlakyTest
+    public void testChildBottomMarginIncluded_flexContainerWrapContent_directionRow_flexShrink()
+            throws Throwable {
+        // This test is to verify the case where:
+        //   - layout_height is set to wrap_content for the FlexboxLayout
+        //   - flex_wrap is set to nowrap for the FlexboxLayout
+        //   - Bottom (or top) margin is set to a child
+        //   - The child which the has the bottom (top) margin has the largest height in the
+        //     same flex line
+        //   - The child has a positive layout_flexShrink attribute set
+        //   - The sum of children width overflows parent's width (shrink will happen)
+        //  If these conditions were met, the height of the FlexboxLayout didn't take the bottom
+        //  margin on the child into account
+        //  See https://github.com/google/flexbox-layout/issues/154
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(
+                        R.layout.activity_wrap_content_child_bottom_margin_row_shrink);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        // layout_height for text1: 24dp, layout_marginBottom: 12dp
+        assertThat(flexboxLayout.getHeight(),
+                isEqualAllowingError(TestUtil.dpToPixel(activity, 36)));
+    }
+
+    @Test
+    @FlakyTest
+    public void testChildBottomMarginIncluded_flexContainerWrapContent_directionColumn_flexShrink()
+            throws Throwable {
+        // This test is to verify the case where:
+        //   - layout_width is set to wrap_content for the FlexboxLayout
+        //   - flex_wrap is set to nowrap for the FlexboxLayout
+        //   - End (or start) margin is set to a child
+        //   - The child which the has the end (start) margin has the largest width in the
+        //     same flex line
+        //   - The child has a positive layout_flexShrink attribute set
+        //   - The sum of children height overflows parent's height (shrink will happen)
+        //  If these conditions were met, the height of the FlexboxLayout didn't take the bottom
+        //  margin on the child into account
+        //  See https://github.com/google/flexbox-layout/issues/154
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(
+                        R.layout.activity_wrap_content_child_bottom_margin_column_shrink);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        // layout_width for text1: 24dp, layout_marginEnd: 12dp
+        assertThat(flexboxLayout.getWidth(),
+                isEqualAllowingError(TestUtil.dpToPixel(activity, 36)));
+    }
+
     private TextView createTextView(Context context, String text, int order) {
         TextView textView = new TextView(context);
         textView.setText(text);

--- a/flexbox/src/androidTest/res/layout/activity_wrap_content_child_bottom_margin_column_grow.xml
+++ b/flexbox/src/androidTest/res/layout/activity_wrap_content_child_bottom_margin_column_grow.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2016 Google Inc. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.google.android.flexbox.FlexboxLayout
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    app:flexDirection="column"
+    app:flexWrap="wrap"
+    app:justifyContent="flex_end" >
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="24dp"
+        android:layout_height="0dp"
+        android:layout_marginEnd="12dp"
+        android:text="1"
+        app:layout_flexBasisPercent="50%"
+        app:layout_flexGrow="1"
+        app:layout_flexShrink="0" />
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/androidTest/res/layout/activity_wrap_content_child_bottom_margin_column_shrink.xml
+++ b/flexbox/src/androidTest/res/layout/activity_wrap_content_child_bottom_margin_column_shrink.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2016 Google Inc. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.google.android.flexbox.FlexboxLayout
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="wrap_content"
+    android:layout_height="200dp"
+    app:flexDirection="column"
+    app:flexWrap="nowrap"
+    app:justifyContent="flex_end" >
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="24dp"
+        android:layout_height="150dp"
+        android:layout_marginEnd="12dp"
+        android:text="1"
+        app:layout_flexShrink="1" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="12dp"
+        android:layout_height="100dp"
+        android:text="2"
+        app:layout_flexShrink="1" />
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/androidTest/res/layout/activity_wrap_content_child_bottom_margin_row_grow.xml
+++ b/flexbox/src/androidTest/res/layout/activity_wrap_content_child_bottom_margin_row_grow.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2016 Google Inc. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<com.google.android.flexbox.FlexboxLayout
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:flexWrap="wrap"
+    app:justifyContent="flex_end" >
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="0dp"
+        android:layout_height="24dp"
+        android:layout_marginBottom="12dp"
+        android:text="test"
+        app:layout_flexBasisPercent="50%"
+        app:layout_flexGrow="1"
+        app:layout_flexShrink="0" />
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/androidTest/res/layout/activity_wrap_content_child_bottom_margin_row_shrink.xml
+++ b/flexbox/src/androidTest/res/layout/activity_wrap_content_child_bottom_margin_row_shrink.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2016 Google Inc. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.google.android.flexbox.FlexboxLayout
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="200dp"
+    android:layout_height="wrap_content"
+    app:flexWrap="nowrap"
+    app:justifyContent="flex_end" >
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="150dp"
+        android:layout_height="24dp"
+        android:layout_marginBottom="12dp"
+        android:text="test1"
+        app:layout_flexShrink="1" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="100dp"
+        android:layout_height="12dp"
+        android:text="test2"
+        app:layout_flexShrink="1" />
+</com.google.android.flexbox.FlexboxLayout>


### PR DESCRIPTION
This PR fixes the case where:
  - layout_width is set to wrap_content for the FlexboxLayout
  - End (or start) margin is set to a child
  - The child which the has the end (start) margin has the largest width in the
    same flex line (or only a single child exists)
  - The child has a positive layout_flexGrow attribute set
If these conditions were met, the width of the FlexboxLayout didn't take the bottom
margin on the child into account.

Fixes #154 