### PR TITLE
Fix the incorrect denominator in the folllowing case

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
@@ -1143,6 +1143,129 @@ public class FlexboxAndroidTest {
 
     @Test
     @FlakyTest
+    public void testJustifyContent_spaceAround_including_gone_views() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_justify_content_with_gone);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                flexboxLayout.setJustifyContent(FlexboxLayout.JUSTIFY_CONTENT_SPACE_AROUND);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        assertThat(flexboxLayout.getJustifyContent(),
+                is(FlexboxLayout.JUSTIFY_CONTENT_SPACE_AROUND));
+
+        TextView textView1 = (TextView) activity.findViewById(R.id.text1);
+        TextView textView3 = (TextView) activity.findViewById(R.id.text3);
+        int space = flexboxLayout.getWidth() - textView1.getWidth()  - textView3.getWidth();
+        space = space / 4; // Divide by the number of visible children * 2
+        assertThat(textView1.getLeft(), isEqualAllowingError(space));
+        int spaceInMiddle = space * 2;
+        assertThat(textView3.getLeft() - textView1.getRight(), isEqualAllowingError(spaceInMiddle));
+        assertThat(flexboxLayout.getRight() - textView3.getRight(), isEqualAllowingError(space));
+    }
+
+    @Test
+    @FlakyTest
+    public void testJustifyContent_spaceBetween_including_gone_views() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_justify_content_with_gone);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                flexboxLayout.setJustifyContent(FlexboxLayout.JUSTIFY_CONTENT_SPACE_BETWEEN);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        assertThat(flexboxLayout.getJustifyContent(),
+                is(FlexboxLayout.JUSTIFY_CONTENT_SPACE_BETWEEN));
+
+        onView(withId(R.id.text1)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text3)).check(isRightAlignedWith(withId(R.id.flexbox_layout)));
+        TextView textView1 = (TextView) activity.findViewById(R.id.text1);
+        TextView textView3 = (TextView) activity.findViewById(R.id.text3);
+        int space = flexboxLayout.getWidth() - textView1.getWidth()  - textView3.getWidth();
+        assertThat(textView3.getLeft() - textView1.getRight(), isEqualAllowingError(space));
+    }
+
+    @Test
+    @FlakyTest
+    public void testJustifyContent_spaceAround_including_gone_views_direction_column()
+            throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_justify_content_with_gone);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                flexboxLayout.setFlexDirection(FlexboxLayout.FLEX_DIRECTION_COLUMN);
+                flexboxLayout.setJustifyContent(FlexboxLayout.JUSTIFY_CONTENT_SPACE_AROUND);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        assertThat(flexboxLayout.getFlexDirection(),
+                is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+        assertThat(flexboxLayout.getJustifyContent(),
+                is(FlexboxLayout.JUSTIFY_CONTENT_SPACE_AROUND));
+
+        TextView textView1 = (TextView) activity.findViewById(R.id.text1);
+        TextView textView3 = (TextView) activity.findViewById(R.id.text3);
+        int space = flexboxLayout.getHeight() - textView1.getHeight()  - textView3.getHeight();
+        space = space / 4; // Divide by the number of visible children * 2
+        assertThat(textView1.getTop(), isEqualAllowingError(space));
+        int spaceInMiddle = space * 2;
+        assertThat(textView3.getTop() - textView1.getBottom(), isEqualAllowingError(spaceInMiddle));
+        assertThat(flexboxLayout.getBottom() - textView3.getBottom(), isEqualAllowingError(space));
+    }
+
+    @Test
+    @FlakyTest
+    public void testJustifyContent_spaceBetween_including_gone_views_direction_column() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.activity_justify_content_with_gone);
+                FlexboxLayout flexboxLayout = (FlexboxLayout) activity
+                        .findViewById(R.id.flexbox_layout);
+                flexboxLayout.setFlexDirection(FlexboxLayout.FLEX_DIRECTION_COLUMN);
+                flexboxLayout.setJustifyContent(FlexboxLayout.JUSTIFY_CONTENT_SPACE_BETWEEN);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        FlexboxLayout flexboxLayout = (FlexboxLayout) activity.findViewById(R.id.flexbox_layout);
+
+        assertThat(flexboxLayout.getFlexDirection(),
+                is(FlexboxLayout.FLEX_DIRECTION_COLUMN));
+        assertThat(flexboxLayout.getJustifyContent(),
+                is(FlexboxLayout.JUSTIFY_CONTENT_SPACE_BETWEEN));
+
+        onView(withId(R.id.text1)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text3)).check(isBottomAlignedWith(withId(R.id.flexbox_layout)));
+        TextView textView1 = (TextView) activity.findViewById(R.id.text1);
+        TextView textView3 = (TextView) activity.findViewById(R.id.text3);
+        int space = flexboxLayout.getHeight() - textView1.getHeight()  - textView3.getHeight();
+        assertThat(textView3.getTop() - textView1.getBottom(), isEqualAllowingError(space));
+    }
+
+    @Test
+    @FlakyTest
     public void testFlexGrow_withExactParentLength() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
         mActivityRule.runOnUiThread(new Runnable() {

--- a/flexbox/src/androidTest/res/layout/activity_justify_content_with_gone.xml
+++ b/flexbox/src/androidTest/res/layout/activity_justify_content_with_gone.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2016 Google Inc. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:flexDirection="row"
+    app:justifyContent="flex_start">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="60dp"
+        android:layout_height="60dp"
+        android:text="1" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="60dp"
+        android:layout_height="60dp"
+        android:text="2"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="60dp"
+        android:layout_height="60dp"
+        android:text="3" />
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexLine.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexLine.java
@@ -56,6 +56,9 @@ public class FlexLine {
     /** @see {@link #getItemCount()} */
     int mItemCount;
 
+    /** Holds the count of the views whose visibilities are gone */
+    int mGoneItemCount;
+
     /** @see {@link #getTotalFlexGrow()} */
     float mTotalFlexGrow;
 
@@ -131,6 +134,13 @@ public class FlexLine {
      */
     public int getItemCount() {
         return mItemCount;
+    }
+
+    /**
+     * @return the count of the views whose visibilities are not gone in this flex line.
+     */
+    public int getItemCountNotGone() {
+        return mItemCount - mGoneItemCount;
     }
 
     /**

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
@@ -555,6 +555,7 @@ public class FlexboxLayout extends ViewGroup {
                     continue;
                 } else if (child.getVisibility() == View.GONE) {
                     flexLine.mItemCount++;
+                    flexLine.mGoneItemCount++;
                     addFlexLineIfLastFlexItem(i, childCount, flexLine);
                     continue;
                 }
@@ -599,7 +600,7 @@ public class FlexboxLayout extends ViewGroup {
                 if (isWrapRequired(widthMode, widthSize, flexLine.mMainSize,
                         child.getMeasuredWidth() + lp.leftMargin + lp.rightMargin, lp,
                         i, indexInFlexLine)) {
-                    if (flexLine.mItemCount > 0) {
+                    if (flexLine.getItemCountNotGone() > 0) {
                         addFlexLine(flexLine);
                     }
 
@@ -717,6 +718,7 @@ public class FlexboxLayout extends ViewGroup {
                 continue;
             } else if (child.getVisibility() == View.GONE) {
                 flexLine.mItemCount++;
+                flexLine.mGoneItemCount++;
                 addFlexLineIfLastFlexItem(i, childCount, flexLine);
                 continue;
             }
@@ -761,7 +763,7 @@ public class FlexboxLayout extends ViewGroup {
             if (isWrapRequired(heightMode, heightSize, flexLine.mMainSize,
                     child.getMeasuredHeight() + lp.topMargin + lp.bottomMargin, lp,
                     i, indexInFlexLine)) {
-                if (flexLine.mItemCount > 0) {
+                if (flexLine.getItemCountNotGone() > 0) {
                     addFlexLine(flexLine);
                 }
 
@@ -833,7 +835,7 @@ public class FlexboxLayout extends ViewGroup {
     }
 
     private void addFlexLineIfLastFlexItem(int childIndex, int childCount, FlexLine flexLine) {
-        if (childIndex == childCount - 1 && flexLine.mItemCount != 0) {
+        if (childIndex == childCount - 1 && flexLine.getItemCountNotGone() != 0) {
             // Add the flex line if this item is the last item
             addFlexLine(flexLine);
         }
@@ -1745,16 +1747,18 @@ public class FlexboxLayout extends ViewGroup {
                     childRight = width - paddingRight - (width - flexLine.mMainSize) / 2f;
                     break;
                 case JUSTIFY_CONTENT_SPACE_AROUND:
-                    if (flexLine.mItemCount != 0) {
+                    int visibleCount = flexLine.getItemCountNotGone();
+                    if (visibleCount != 0) {
                         spaceBetweenItem = (width - flexLine.mMainSize)
-                                / (float) flexLine.mItemCount;
+                                / (float) visibleCount;
                     }
                     childLeft = paddingLeft + spaceBetweenItem / 2f;
                     childRight = width - paddingRight - spaceBetweenItem / 2f;
                     break;
                 case JUSTIFY_CONTENT_SPACE_BETWEEN:
                     childLeft = paddingLeft;
-                    float denominator = flexLine.mItemCount != 1 ? flexLine.mItemCount - 1 : 1f;
+                    int visibleItem = flexLine.getItemCountNotGone();
+                    float denominator = visibleItem != 1 ? visibleItem - 1 : 1f;
                     spaceBetweenItem = (width - flexLine.mMainSize) / denominator;
                     childRight = width - paddingRight;
                     break;
@@ -1961,16 +1965,18 @@ public class FlexboxLayout extends ViewGroup {
                     childBottom = height - paddingBottom - (height - flexLine.mMainSize) / 2f;
                     break;
                 case JUSTIFY_CONTENT_SPACE_AROUND:
-                    if (flexLine.mItemCount != 0) {
+                    int visibleCount = flexLine.getItemCountNotGone();
+                    if (visibleCount != 0) {
                         spaceBetweenItem = (height - flexLine.mMainSize)
-                                / (float) flexLine.mItemCount;
+                                / (float) visibleCount;
                     }
                     childTop = paddingTop + spaceBetweenItem / 2f;
                     childBottom = height - paddingBottom - spaceBetweenItem / 2f;
                     break;
                 case JUSTIFY_CONTENT_SPACE_BETWEEN:
                     childTop = paddingTop;
-                    float denominator = flexLine.mItemCount != 1 ? flexLine.mItemCount - 1 : 1f;
+                    int visibleItem = flexLine.getItemCountNotGone();
+                    float denominator = visibleItem != 1 ? visibleItem - 1 : 1f;
                     spaceBetweenItem = (height - flexLine.mMainSize) / denominator;
                     childBottom = height - paddingBottom;
                     break;
@@ -2167,6 +2173,9 @@ public class FlexboxLayout extends ViewGroup {
             FlexLine flexLine = mFlexLines.get(i);
             for (int j = 0; j < flexLine.mItemCount; j++) {
                 View view = getReorderedChildAt(currentViewIndex);
+                if (view == null || view.getVisibility() == View.GONE) {
+                    continue;
+                }
                 LayoutParams lp = (LayoutParams) view.getLayoutParams();
 
                 // Judge if the beginning or middle divider is needed
@@ -2247,6 +2256,9 @@ public class FlexboxLayout extends ViewGroup {
             // Draw horizontal dividers if needed
             for (int j = 0; j < flexLine.mItemCount; j++) {
                 View view = getReorderedChildAt(currentViewIndex);
+                if (view == null || view.getVisibility() == View.GONE) {
+                    continue;
+                }
                 LayoutParams lp = (LayoutParams) view.getLayoutParams();
 
                 // Judge if the beginning or middle divider is needed
@@ -2405,7 +2417,7 @@ public class FlexboxLayout extends ViewGroup {
     public List<FlexLine> getFlexLines() {
         List<FlexLine> result = new ArrayList<>(mFlexLines.size());
         for (FlexLine flexLine : mFlexLines) {
-            if (flexLine.getItemCount() == 0) {
+            if (flexLine.getItemCountNotGone() == 0) {
                 continue;
             }
             result.add(flexLine);
@@ -2613,7 +2625,7 @@ public class FlexboxLayout extends ViewGroup {
 
     private boolean allFlexLinesAreDummyBefore(int flexLineIndex) {
         for (int i = 0; i < flexLineIndex; i++) {
-            if (mFlexLines.get(i).mItemCount > 0) {
+            if (mFlexLines.get(i).getItemCountNotGone() > 0) {
                 return false;
             }
         }
@@ -2632,7 +2644,7 @@ public class FlexboxLayout extends ViewGroup {
         }
 
         for (int i = flexLineIndex + 1; i < mFlexLines.size(); i++) {
-            if (mFlexLines.get(i).mItemCount > 0) {
+            if (mFlexLines.get(i).getItemCountNotGone() > 0) {
                 return false;
             }
         }


### PR DESCRIPTION
This PR fixes the incorrect alignment where:
- justifyContent is set to either or space_between or space_around
- Views whose visibitilies are gone are included in a flex line

Also use the number of item count, which the number of gone items are filtered
where appropriate.

Fixes #162