### PR TITLE
Fix the stretching views calculation when the calculation happens from the  middle of the items.

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
@@ -1580,6 +1580,108 @@ public class FlexboxLayoutManagerTest {
                 isEqualAllowingError(TestUtil.dpToPixel(activity, 80)));
     }
 
+    @Test
+    @FlakyTest
+    public void testStretchViews_from_middle_direction_row() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final TestAdapter adapter = new TestAdapter();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.recyclerview);
+                RecyclerView recyclerView = (RecyclerView) activity.findViewById(R.id.recyclerview);
+                layoutManager.setFlexDirection(FlexDirection.ROW);
+                layoutManager.setAlignItems(AlignItems.STRETCH);
+                recyclerView.setLayoutManager(layoutManager);
+                recyclerView.setAdapter(adapter);
+                for (int i = 0; i < 50; i++) {
+                    FlexboxLayoutManager.LayoutParams lp = createLayoutParams(activity, 70, 80);
+                    adapter.addItem(lp);
+                }
+                // RecyclerView width: 320, height: 240.
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        assertThat(layoutManager.getFlexDirection(), is(FlexDirection.ROW));
+        assertThat(layoutManager.getAlignItems(), is(AlignItems.STRETCH));
+
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.BOTTOM_CENTER,
+                GeneralLocation.TOP_CENTER));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.BOTTOM_CENTER,
+                GeneralLocation.TOP_CENTER));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.BOTTOM_CENTER,
+                GeneralLocation.TOP_CENTER));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.BOTTOM_CENTER,
+                GeneralLocation.TOP_CENTER));
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                layoutManager.setAlignItems(AlignItems.STRETCH);
+                FlexboxLayoutManager.LayoutParams lp = createLayoutParams(activity, 70, 20);
+                // Add an item whose height is less than the other items.
+                // But with alignItems set to stretch, the height of the item should be stretched
+                adapter.addItem(lp);
+                adapter.notifyDataSetChanged();
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        assertThat(layoutManager.getChildAt(layoutManager.getChildCount() - 1).getHeight(),
+                isEqualAllowingError(TestUtil.dpToPixel(activity, 80)));
+    }
+
+    @Test
+    @FlakyTest
+    public void testStretchViews_from_middle_direction_column() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final TestAdapter adapter = new TestAdapter();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.recyclerview);
+                RecyclerView recyclerView = (RecyclerView) activity.findViewById(R.id.recyclerview);
+                layoutManager.setFlexDirection(FlexDirection.COLUMN);
+                layoutManager.setAlignItems(AlignItems.STRETCH);
+                recyclerView.setLayoutManager(layoutManager);
+                recyclerView.setAdapter(adapter);
+                for (int i = 0; i < 50; i++) {
+                    FlexboxLayoutManager.LayoutParams lp = createLayoutParams(activity, 70, 50);
+                    adapter.addItem(lp);
+                }
+                // RecyclerView width: 320, height: 240.
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        assertThat(layoutManager.getFlexDirection(), is(FlexDirection.COLUMN));
+        assertThat(layoutManager.getAlignItems(), is(AlignItems.STRETCH));
+
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.BOTTOM_RIGHT,
+                GeneralLocation.TOP_LEFT));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.BOTTOM_RIGHT,
+                GeneralLocation.TOP_LEFT));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.BOTTOM_RIGHT,
+                GeneralLocation.TOP_LEFT));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.BOTTOM_RIGHT,
+                GeneralLocation.TOP_LEFT));
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                layoutManager.setAlignItems(AlignItems.STRETCH);
+                FlexboxLayoutManager.LayoutParams lp = createLayoutParams(activity, 20, 50);
+                // Add an item whose width is less than the other items.
+                // But with alignItems set to stretch, the width of the item should be stretched
+                adapter.addItem(lp);
+                adapter.notifyDataSetChanged();
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        assertThat(layoutManager.getChildAt(layoutManager.getChildCount() - 1).getWidth(),
+                isEqualAllowingError(TestUtil.dpToPixel(activity, 70)));
+    }
+
     /**
      * Creates a new flex item.
      *

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
@@ -733,7 +733,13 @@ class FlexboxHelper {
                 throw new IllegalArgumentException("Invalid flex direction: " + flexDirection);
         }
 
-        for (FlexLine flexLine : mFlexContainer.getFlexLinesInternal()) {
+        int flexLineIndex = 0;
+        if (mIndexToFlexLine != null) {
+            flexLineIndex = mIndexToFlexLine[fromIndex];
+        }
+        List<FlexLine> flexLines = mFlexContainer.getFlexLinesInternal();
+        for (int i = flexLineIndex, size = flexLines.size(); i < size; i++) {
+            FlexLine flexLine = flexLines.get(i);
             if (flexLine.mMainSize < mainSize) {
                 fromIndex = expandFlexItems(widthMeasureSpec, heightMeasureSpec, flexLine,
                         mainSize, paddingAlongMainAxis, fromIndex, false);
@@ -1301,10 +1307,19 @@ class FlexboxHelper {
         int flexDirection = mFlexContainer.getFlexDirection();
         if (mFlexContainer.getAlignItems() == AlignItems.STRETCH) {
             int viewIndex = fromIndex;
-            for (FlexLine flexLine : mFlexContainer.getFlexLinesInternal()) {
-                for (int i = 0, itemCount = flexLine.mItemCount; i < itemCount;
-                        i++, viewIndex++) {
+            int flexLineIndex = 0;
+            if (mIndexToFlexLine != null) {
+                flexLineIndex = mIndexToFlexLine[fromIndex];
+            }
+            List<FlexLine> flexLines = mFlexContainer.getFlexLinesInternal();
+            for (int i = flexLineIndex, size = flexLines.size(); i < size; i++) {
+                FlexLine flexLine = flexLines.get(i);
+                for (int j = 0, itemCount = flexLine.mItemCount; j < itemCount;
+                        j++, viewIndex++) {
                     View view = mFlexContainer.getReorderedFlexItemAt(viewIndex);
+                    if (view == null || view.getVisibility() == View.GONE) {
+                        continue;
+                    }
                     FlexItem flexItem = (FlexItem) view.getLayoutParams();
                     if (flexItem.getAlignSelf() != AlignSelf.AUTO &&
                             flexItem.getAlignSelf() != AlignItems.STRETCH) {


### PR DESCRIPTION
When the calculation of stretching views happen from the middle of the items, the  flex line being processed needs to be the corresponding one depending on the index of the view.
This PR correctly handles the flex line.

E.g. A new item is added on the condition that RecyclerView is scrolled to the
bottom and align items is set to stretch
