### PR TITLE
Improvement in the demo app and several fixes.

### DIFF
--- a/app/src/main/java/com/google/android/flexbox/FlexItemEditFragment.java
+++ b/app/src/main/java/com/google/android/flexbox/FlexItemEditFragment.java
@@ -137,6 +137,10 @@ public class FlexItemEditFragment extends DialogFragment {
         orderEdit.addTextChangedListener(
                 new FlexEditTextWatcher(orderTextInput, new IntegerInputValidator(),
                         R.string.must_be_integer));
+        if (mFlexItem instanceof FlexboxLayoutManager.LayoutParams) {
+            // Order is not enabled in FlexboxLayoutManager
+            orderEdit.setEnabled(false);
+        }
 
         final TextInputLayout flexGrowInput = (TextInputLayout) view
                 .findViewById(R.id.input_layout_flex_grow);

--- a/app/src/main/java/com/google/android/flexbox/FragmentHelper.java
+++ b/app/src/main/java/com/google/android/flexbox/FragmentHelper.java
@@ -27,6 +27,7 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Spinner;
+import android.widget.Toast;
 
 /**
  * Helper class that has the common logic for initializing the Fragment for the play ground demo
@@ -71,6 +72,7 @@ class FragmentHelper {
     private FlexContainer mFlexContainer;
 
     private SharedPreferences mSharedPreferences;
+
 
     FragmentHelper(MainActivity mainActivity, FlexContainer flexContainer) {
         mActivity = mainActivity;
@@ -124,9 +126,12 @@ class FragmentHelper {
         flexItem.setHeight(Util.dpToPixel(mActivity,
                 readPreferenceAsInteger(mActivity.getString(R.string.new_height_key),
                         DEFAULT_HEIGHT)));
-        flexItem.setOrder(
-                readPreferenceAsInteger(mActivity.getString(R.string.new_flex_item_order_key),
-                        "1"));
+        // Order is not supported in the FlexboxLayoutManager
+        if (!(flexItem instanceof FlexboxLayoutManager.LayoutParams)) {
+            flexItem.setOrder(
+                    readPreferenceAsInteger(mActivity.getString(R.string.new_flex_item_order_key),
+                            "1"));
+        }
         flexItem.setFlexGrow(
                 readPreferenceAsFloat(mActivity.getString(R.string.new_flex_grow_key), "0.0"));
         flexItem.setFlexShrink(
@@ -228,7 +233,15 @@ class FragmentHelper {
                         } else if (selected.equals(WRAP_REVERSE)) {
                             flexWrap = FlexWrap.WRAP_REVERSE;
                         }
-                        mFlexContainer.setFlexWrap(flexWrap);
+
+                        if (mFlexContainer instanceof FlexboxLayoutManager &&
+                                flexWrap == FlexWrap.WRAP_REVERSE) {
+                            Toast.makeText(mActivity,
+                                    R.string.wrap_reverse_not_supported,
+                                    Toast.LENGTH_SHORT).show();
+                        } else {
+                            mFlexContainer.setFlexWrap(flexWrap);
+                        }
                     }
 
                     @Override
@@ -370,7 +383,13 @@ class FragmentHelper {
                         } else if (selected.equals(STRETCH)) {
                             alignContent = AlignContent.STRETCH;
                         }
-                        mFlexContainer.setAlignContent(alignContent);
+
+                        if (mFlexContainer instanceof FlexboxLayoutManager) {
+                            Toast.makeText(mActivity, R.string.align_content_not_supported,
+                                    Toast.LENGTH_SHORT).show();
+                        } else {
+                            mFlexContainer.setAlignContent(alignContent);
+                        }
                     }
 
                     @Override

--- a/app/src/main/java/com/google/android/flexbox/MainActivity.java
+++ b/app/src/main/java/com/google/android/flexbox/MainActivity.java
@@ -59,24 +59,21 @@ public class MainActivity extends AppCompatActivity
         RadioGroup radioGroup = (RadioGroup) navigationView.getHeaderView(0)
                 .findViewById(R.id.radiogroup_container_implementation);
         final FragmentManager fragmentManager = getSupportFragmentManager();
+
         radioGroup.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(RadioGroup radioGroup, int checkedId) {
                 if (checkedId == R.id.radiobutton_viewgroup) {
                     replaceToFlexboxLayoutFragment(fragmentManager);
                 } else {
-                    RecyclerViewFragment fragment = (RecyclerViewFragment)
-                            fragmentManager.findFragmentByTag(RECYCLERVIEW_FRAGMENT);
-                    if (fragment == null) {
-                        fragment = RecyclerViewFragment.newInstance();
-                    }
-                    fragmentManager.beginTransaction()
-                            .replace(R.id.container, fragment, RECYCLERVIEW_FRAGMENT).commit();
+                    replaceToRecyclerViewFragment(fragmentManager);
                 }
             }
         });
 
-        replaceToFlexboxLayoutFragment(fragmentManager);
+        if (savedInstanceState == null) {
+            replaceToFlexboxLayoutFragment(fragmentManager);
+        }
     }
 
     private void replaceToFlexboxLayoutFragment(FragmentManager fragmentManager) {
@@ -87,6 +84,16 @@ public class MainActivity extends AppCompatActivity
         }
         fragmentManager.beginTransaction()
                 .replace(R.id.container, fragment, FLEXBOXLAYOUT_FRAGMENT).commit();
+    }
+
+    private void replaceToRecyclerViewFragment(FragmentManager fragmentManager) {
+        RecyclerViewFragment fragment = (RecyclerViewFragment)
+                fragmentManager.findFragmentByTag(RECYCLERVIEW_FRAGMENT);
+        if (fragment == null) {
+            fragment = RecyclerViewFragment.newInstance();
+        }
+        fragmentManager.beginTransaction()
+                .replace(R.id.container, fragment, RECYCLERVIEW_FRAGMENT).commit();
     }
 
     @Override

--- a/app/src/main/java/com/google/android/flexbox/RecyclerViewFragment.java
+++ b/app/src/main/java/com/google/android/flexbox/RecyclerViewFragment.java
@@ -28,15 +28,21 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.util.ArrayList;
+
 /**
  * Fragment that contains the {@link RecyclerView} and the {@link FlexboxLayoutManager} as its
  * LayoutManager for the flexbox playground.
  */
 public class RecyclerViewFragment extends Fragment {
 
+    private static final String FLEX_ITEMS_KEY = "flex_items";
+
     public static RecyclerViewFragment newInstance() {
         return new RecyclerViewFragment();
     }
+
+    private FlexItemAdapter mAdapter;
 
     @Nullable
     @Override
@@ -54,8 +60,19 @@ public class RecyclerViewFragment extends Fragment {
         final FlexboxLayoutManager flexboxLayoutManager = new FlexboxLayoutManager();
         final MainActivity activity = (MainActivity) getActivity();
         recyclerView.setLayoutManager(flexboxLayoutManager);
-        final FlexItemAdapter adapter = new FlexItemAdapter(activity, flexboxLayoutManager);
-        recyclerView.setAdapter(adapter);
+        if (mAdapter == null) {
+            mAdapter = new FlexItemAdapter(activity, flexboxLayoutManager);
+        }
+        recyclerView.setAdapter(mAdapter);
+        if (savedInstanceState != null) {
+            ArrayList<FlexboxLayoutManager.LayoutParams> layoutParams = savedInstanceState
+                    .getParcelableArrayList(FLEX_ITEMS_KEY);
+            assert layoutParams != null;
+            for (int i = 0; i < layoutParams.size(); i++) {
+                mAdapter.addItem(layoutParams.get(i));
+            }
+            mAdapter.notifyDataSetChanged();
+        }
         final FragmentHelper fragmentHelper = new FragmentHelper(activity, flexboxLayoutManager);
         fragmentHelper.initializeViews();
 
@@ -69,8 +86,8 @@ public class RecyclerViewFragment extends Fragment {
                             ViewGroup.LayoutParams.WRAP_CONTENT,
                             ViewGroup.LayoutParams.WRAP_CONTENT);
                     fragmentHelper.setFlexItemAttributes(lp);
-                    adapter.addItem(lp);
-                    adapter.notifyDataSetChanged();
+                    mAdapter.addItem(lp);
+                    mAdapter.notifyDataSetChanged();
                 }
             });
         }
@@ -80,15 +97,21 @@ public class RecyclerViewFragment extends Fragment {
             removeFab.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    if (adapter.getItemCount() == 0) {
+                    if (mAdapter.getItemCount() == 0) {
                         return;
                     }
-                    adapter.removeItem(adapter.getItemCount() - 1);
+                    mAdapter.removeItem(mAdapter.getItemCount() - 1);
 
                     // TODO: Specify index?
-                    adapter.notifyDataSetChanged();
+                    mAdapter.notifyDataSetChanged();
                 }
             });
         }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putParcelableArrayList(FLEX_ITEMS_KEY, new ArrayList<>(mAdapter.getItems()));
     }
 }

--- a/app/src/main/java/com/google/android/flexbox/recyclerview/FlexItemAdapter.java
+++ b/app/src/main/java/com/google/android/flexbox/recyclerview/FlexItemAdapter.java
@@ -28,6 +28,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -39,7 +40,7 @@ public class FlexItemAdapter extends RecyclerView.Adapter<FlexItemViewHolder> {
 
     private FlexboxLayoutManager mLayoutManager;
 
-    private List<RecyclerView.LayoutParams> mLayoutParams;
+    private List<FlexboxLayoutManager.LayoutParams> mLayoutParams;
 
     public FlexItemAdapter(AppCompatActivity activity, FlexboxLayoutManager layoutManager) {
         mActivity = activity;
@@ -62,7 +63,7 @@ public class FlexItemAdapter extends RecyclerView.Adapter<FlexItemViewHolder> {
         holder.bindTo(mLayoutParams.get(position));
     }
 
-    public void addItem(RecyclerView.LayoutParams lp) {
+    public void addItem(FlexboxLayoutManager.LayoutParams lp) {
         mLayoutParams.add(lp);
     }
 
@@ -71,6 +72,10 @@ public class FlexItemAdapter extends RecyclerView.Adapter<FlexItemViewHolder> {
             return;
         }
         mLayoutParams.remove(position);
+    }
+
+    public List<FlexboxLayoutManager.LayoutParams> getItems() {
+        return Collections.unmodifiableList(mLayoutParams);
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,4 +131,6 @@ limitations under the License.
     <string name="viewgroup">ViewGroup</string>
     <string name="recyclerview">RecyclerView</string>
     <string name="underlying_implementation">Underlying implementation</string>
+    <string name="align_content_not_supported">Setting the alignContent in FlexboxLayoutManager is not supported. Ignoring.</string>
+    <string name="wrap_reverse_not_supported">wrap_reverse is not supporeted in the FlexboxLayoutManager.</string>
 </resources>

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
@@ -16,7 +16,6 @@
 
 package com.google.android.flexbox.test;
 
-import com.google.android.flexbox.AlignContent;
 import com.google.android.flexbox.AlignItems;
 import com.google.android.flexbox.AlignSelf;
 import com.google.android.flexbox.FlexDirection;
@@ -79,7 +78,7 @@ public class FlexboxLayoutManagerTest {
         assertThat(layoutManager, is(instanceOf(FlexboxLayoutManager.class)));
         FlexboxLayoutManager flexboxLayoutManager = (FlexboxLayoutManager) layoutManager;
         assertThat(flexboxLayoutManager.getFlexDirection(), is(FlexDirection.ROW_REVERSE));
-        assertThat(flexboxLayoutManager.getFlexWrap(), is(FlexWrap.WRAP_REVERSE));
+        assertThat(flexboxLayoutManager.getFlexWrap(), is(FlexWrap.WRAP));
     }
 
     @Test
@@ -98,18 +97,16 @@ public class FlexboxLayoutManagerTest {
         assertThat(layoutManager, is(instanceOf(FlexboxLayoutManager.class)));
         FlexboxLayoutManager flexboxLayoutManager = (FlexboxLayoutManager) layoutManager;
         assertThat(flexboxLayoutManager.getFlexDirection(), is(FlexDirection.ROW_REVERSE));
-        assertThat(flexboxLayoutManager.getFlexWrap(), is(FlexWrap.WRAP_REVERSE));
+        assertThat(flexboxLayoutManager.getFlexWrap(), is(FlexWrap.WRAP));
 
         flexboxLayoutManager.setFlexDirection(FlexDirection.COLUMN);
         flexboxLayoutManager.setFlexWrap(FlexWrap.NOWRAP);
         flexboxLayoutManager.setJustifyContent(JustifyContent.CENTER);
         flexboxLayoutManager.setAlignItems(AlignItems.FLEX_END);
-        flexboxLayoutManager.setAlignContent(AlignContent.SPACE_BETWEEN);
         assertThat(flexboxLayoutManager.getFlexDirection(), is(FlexDirection.COLUMN));
         assertThat(flexboxLayoutManager.getFlexWrap(), is(FlexWrap.NOWRAP));
         assertThat(flexboxLayoutManager.getJustifyContent(), is(JustifyContent.CENTER));
         assertThat(flexboxLayoutManager.getAlignItems(), is(AlignItems.FLEX_END));
-        assertThat(flexboxLayoutManager.getAlignContent(), is(AlignContent.SPACE_BETWEEN));
     }
 
     @Test

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
@@ -701,6 +701,9 @@ class FlexboxHelper {
      */
     void determineMainSize(int widthMeasureSpec, int heightMeasureSpec, int fromIndex) {
         ensureChildrenFrozen(mFlexContainer.getFlexItemCount());
+        if (fromIndex >= mFlexContainer.getFlexItemCount()) {
+            return;
+        }
         int mainSize;
         int paddingAlongMainAxis;
         int flexDirection = mFlexContainer.getFlexDirection();
@@ -1304,6 +1307,9 @@ class FlexboxHelper {
      * @see FlexboxLayout.LayoutParams#mAlignSelf
      */
     void stretchViews(int fromIndex) {
+        if (fromIndex >= mFlexContainer.getFlexItemCount()) {
+            return;
+        }
         int flexDirection = mFlexContainer.getFlexDirection();
         if (mFlexContainer.getAlignItems() == AlignItems.STRETCH) {
             int viewIndex = fromIndex;


### PR DESCRIPTION
- Preserve the flex items state across a configuration change in the demo app
- Throw an Exception when order or alignContent which aren't supported by
  FlexboxLayoutManager are changed (setXXXX is invoked)
- Clear the existing flex lines and views if an incompatible, in which prior views
  states or flex lines states can't be shared, attribute change happens
  (e.g. flex direction is changd from row to column)