### PR TITLE
Fix the issue cross size is not calculated correctly with the following condition

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
@@ -1900,6 +1900,72 @@ public class FlexboxLayoutManagerTest {
         assertThat(((TextView) layoutManager.getChildAt(0)).getText().toString(), is("1"));
     }
 
+    @Test
+    @FlakyTest
+    public void testFlexGrow_only_oneItem_has_positive_direction_row() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final TestAdapter adapter = new TestAdapter();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.recyclerview);
+                RecyclerView recyclerView = (RecyclerView) activity.findViewById(R.id.recyclerview);
+                layoutManager.setFlexDirection(FlexDirection.ROW);
+                recyclerView.setLayoutManager(layoutManager);
+                recyclerView.setAdapter(adapter);
+                for (int i = 0; i < 4; i++) {
+                    FlexboxLayoutManager.LayoutParams lp = createLayoutParams(activity, 100, 80);
+                    adapter.addItem(lp);
+                }
+                // RecyclerView width: 320, height: 240.
+                // Flex line 1: 3 items
+                // Flex line 2: 1 item
+                // Give the second item in the first line a positive flex grow
+                adapter.getItemAt(0).setHeight(TestUtil.dpToPixel(activity, 140));
+                adapter.getItemAt(1).setFlexGrow(1.0f);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        assertThat(layoutManager.getFlexDirection(), is(FlexDirection.ROW));
+        // Verify the vertical position (cross size) of the second line is correctly positioned
+        assertThat(layoutManager.getChildAt(3).getTop(),
+                isEqualAllowingError(TestUtil.dpToPixel(activity, 140)));
+    }
+
+    @Test
+    @FlakyTest
+    public void testFlexGrow_only_oneItem_has_positive_direction_column() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final TestAdapter adapter = new TestAdapter();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.recyclerview);
+                RecyclerView recyclerView = (RecyclerView) activity.findViewById(R.id.recyclerview);
+                layoutManager.setFlexDirection(FlexDirection.COLUMN);
+                recyclerView.setLayoutManager(layoutManager);
+                recyclerView.setAdapter(adapter);
+                for (int i = 0; i < 4; i++) {
+                    FlexboxLayoutManager.LayoutParams lp = createLayoutParams(activity, 70, 70);
+                    adapter.addItem(lp);
+                }
+                // RecyclerView width: 320, height: 240.
+                // Flex line 1: 3 items
+                // Flex line 2: 1 item
+                // Give the second item in the first line a positive flex grow
+                adapter.getItemAt(0).setWidth(TestUtil.dpToPixel(activity, 120));
+                adapter.getItemAt(1).setFlexGrow(1.0f);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        assertThat(layoutManager.getFlexDirection(), is(FlexDirection.COLUMN));
+        // Verify the horizontal position (cross size) of the second line is correctly positioned
+        assertThat(layoutManager.getChildAt(3).getLeft(),
+                isEqualAllowingError(TestUtil.dpToPixel(activity, 120)));
+    }
+
     /**
      * Creates a new flex item.
      *

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/TestAdapter.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/TestAdapter.java
@@ -16,6 +16,8 @@
 
 package com.google.android.flexbox.test;
 
+import com.google.android.flexbox.FlexboxLayoutManager;
+
 import android.support.v7.widget.RecyclerView;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -30,13 +32,13 @@ import java.util.List;
  */
 class TestAdapter extends RecyclerView.Adapter<TestViewHolder> {
 
-    private List<RecyclerView.LayoutParams> mLayoutParams;
+    private List<FlexboxLayoutManager.LayoutParams> mLayoutParams;
 
     TestAdapter() {
-        this(new ArrayList<RecyclerView.LayoutParams>());
+        this(new ArrayList<FlexboxLayoutManager.LayoutParams>());
     }
 
-    TestAdapter(List<RecyclerView.LayoutParams> flexItems) {
+    TestAdapter(List<FlexboxLayoutManager.LayoutParams> flexItems) {
         mLayoutParams = flexItems;
     }
 
@@ -52,10 +54,10 @@ class TestAdapter extends RecyclerView.Adapter<TestViewHolder> {
         holder.mTextView.setText(String.valueOf(position + 1));
         holder.mTextView.setBackgroundResource(R.drawable.flex_item_background);
         holder.mTextView.setGravity(Gravity.CENTER);
-        holder.mItemView.setLayoutParams(mLayoutParams.get(position));
+        holder.mTextView.setLayoutParams(mLayoutParams.get(position));
     }
 
-    public void addItem(RecyclerView.LayoutParams flexItem) {
+    public void addItem(FlexboxLayoutManager.LayoutParams flexItem) {
         mLayoutParams.add(flexItem);
     }
 
@@ -64,6 +66,10 @@ class TestAdapter extends RecyclerView.Adapter<TestViewHolder> {
             return;
         }
         mLayoutParams.remove(position);
+    }
+
+    public FlexboxLayoutManager.LayoutParams getItemAt(int index) {
+        return mLayoutParams.get(index);
     }
 
     @Override

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/TestViewHolder.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/TestViewHolder.java
@@ -26,12 +26,10 @@ import android.widget.TextView;
 class TestViewHolder extends RecyclerView.ViewHolder {
 
     TextView mTextView;
-    View mItemView;
 
     TestViewHolder(View itemView) {
         super(itemView);
 
-        mItemView = itemView;
         mTextView = (TextView) itemView.findViewById(R.id.textview);
     }
 }


### PR DESCRIPTION
- Flex line has multiple flex itmes.
- Flex grow attributes for some items are set to positive, the rest of the
  items have the default value
- The item which hasn't the positive flex grow attribute has the largest cross
  size