### PR TITLE
Detach the existing views instead of removing them

### DIFF
--- a/app/src/main/java/com/google/android/flexbox/FlexItemChangedListenerImplRecyclerView.java
+++ b/app/src/main/java/com/google/android/flexbox/FlexItemChangedListenerImplRecyclerView.java
@@ -40,6 +40,9 @@ public class FlexItemChangedListenerImplRecyclerView implements FlexItemChangedL
     public void onFlexItemChanged(FlexItem flexItem, int viewIndex) {
         View view = mFlexContainer.getFlexItemAt(viewIndex);
         view.setLayoutParams((ViewGroup.LayoutParams) flexItem);
-        mAdapter.notifyItemChanged(viewIndex);
+        mAdapter.notifyDataSetChanged();
+        // TODO: An Exception is thrown if notifyItemChanged(int) is used.
+        // Investigate that, but using LinearLayoutManager also produces the same Exception
+        // java.lang.IllegalArgumentException: Called attach on a child which is not detached:
     }
 }

--- a/app/src/main/java/com/google/android/flexbox/RecyclerViewFragment.java
+++ b/app/src/main/java/com/google/android/flexbox/RecyclerViewFragment.java
@@ -16,9 +16,6 @@
 
 package com.google.android.flexbox;
 
-import com.google.android.apps.flexbox.R;
-import com.google.android.flexbox.recyclerview.FlexItemAdapter;
-
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.design.widget.FloatingActionButton;
@@ -27,7 +24,8 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-
+import com.google.android.apps.flexbox.R;
+import com.google.android.flexbox.recyclerview.FlexItemAdapter;
 import java.util.ArrayList;
 
 /**
@@ -87,7 +85,6 @@ public class RecyclerViewFragment extends Fragment {
                             ViewGroup.LayoutParams.WRAP_CONTENT);
                     fragmentHelper.setFlexItemAttributes(lp);
                     mAdapter.addItem(lp);
-                    mAdapter.notifyDataSetChanged();
                 }
             });
         }
@@ -101,9 +98,6 @@ public class RecyclerViewFragment extends Fragment {
                         return;
                     }
                     mAdapter.removeItem(mAdapter.getItemCount() - 1);
-
-                    // TODO: Specify index?
-                    mAdapter.notifyDataSetChanged();
                 }
             });
         }

--- a/app/src/main/java/com/google/android/flexbox/recyclerview/FlexItemAdapter.java
+++ b/app/src/main/java/com/google/android/flexbox/recyclerview/FlexItemAdapter.java
@@ -58,6 +58,7 @@ public class FlexItemAdapter extends RecyclerView.Adapter<FlexItemViewHolder> {
     @Override
     public void onBindViewHolder(FlexItemViewHolder holder, int position) {
         int adapterPosition = holder.getAdapterPosition();
+        // TODO: More optimized set the click listener inside the view holder
         holder.itemView.setOnClickListener(new FlexItemClickListener(mActivity,
                 new FlexItemChangedListenerImplRecyclerView(mLayoutManager, this),
                 adapterPosition));
@@ -66,6 +67,7 @@ public class FlexItemAdapter extends RecyclerView.Adapter<FlexItemViewHolder> {
 
     public void addItem(FlexboxLayoutManager.LayoutParams lp) {
         mLayoutParams.add(lp);
+        notifyItemInserted(mLayoutParams.size() - 1);
     }
 
     public void removeItem(int position) {
@@ -73,6 +75,8 @@ public class FlexItemAdapter extends RecyclerView.Adapter<FlexItemViewHolder> {
             return;
         }
         mLayoutParams.remove(position);
+        notifyItemRemoved(mLayoutParams.size());
+        notifyItemRangeChanged(position, mLayoutParams.size());
     }
 
     public List<FlexboxLayoutManager.LayoutParams> getItems() {


### PR DESCRIPTION
in the onLayoutChildren for better performance.

When a view holder is retrieved from the detached state (scrap), it doesn't go
through the Adapter, thus it should be more optimized than re-creating fro the
Adapter.