### PR TITLE
Simplify non-negative decimal validation

### DIFF
--- a/app/src/main/java/com/google/android/apps/flexbox/validators/NonNegativeDecimalInputValidator.java
+++ b/app/src/main/java/com/google/android/apps/flexbox/validators/NonNegativeDecimalInputValidator.java
@@ -26,10 +26,9 @@ public class NonNegativeDecimalInputValidator implements InputValidator {
     @Override
     public boolean isValidInput(CharSequence charSequence) {
         try {
-            Float.parseFloat(charSequence.toString());
+            return !TextUtils.isEmpty(charSequence) && Float.valueOf(charSequence.toString()) >= 0;
         } catch (NumberFormatException | NullPointerException ignore) {
             return false;
         }
-        return !TextUtils.isEmpty(charSequence) && Float.valueOf(charSequence.toString()) >= 0;
     }
 }


### PR DESCRIPTION
Android Studio warns that the result of `Float.parseFloat` is ignored, and with a little cord re-ordering we can avoid that.