### PR TITLE
supports match parent attribute.

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
@@ -1743,6 +1743,108 @@ public class FlexboxAndroidTest {
 
     @Test
     @FlakyTest
+    public void testWidthMatchParent_flexDirection_row() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        FlexboxLayout flexboxLayout = createFlexboxLayout(
+                R.layout.activity_width_match_parent_direction_row_test);
+
+        onView(withId(R.id.text1)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text1)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isBelow(withId(R.id.text1)));
+        onView(withId(R.id.text2)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text3)).check(isBelow(withId(R.id.text2)));
+        onView(withId(R.id.text3)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+
+        // There should be 3 flex lines in the layout with the given layout.
+        // Only the second TextView's width is set to match_parent.
+        int flexLineWidth = flexboxLayout.getWidth();
+        TextView textView1 = (TextView) activity.findViewById(R.id.text1);
+        TextView textView2 = (TextView) activity.findViewById(R.id.text2);
+        TextView textView3 = (TextView) activity.findViewById(R.id.text3);
+        assertThat(textView1.getWidth(), not(flexLineWidth));
+        assertThat(textView2.getWidth(), isEqualAllowingError(flexLineWidth));
+        assertThat(textView3.getWidth(), not(flexLineWidth));
+    }
+
+    @Test
+    @FlakyTest
+    public void testWidthMatchParent_flexDirection_column() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        FlexboxLayout flexboxLayout = createFlexboxLayout(
+                R.layout.activity_width_match_parent_direction_column_test);
+
+        onView(withId(R.id.text1)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text1)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isBelow(withId(R.id.text1)));
+        onView(withId(R.id.text2)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text3)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text3)).check(isRightOf(withId(R.id.text1)));
+        onView(withId(R.id.text3)).check(isRightOf(withId(R.id.text2)));
+
+        // There should be 2 flex lines in the layout with the given layout.
+        // Only the second TextView's width is set to match_parent.
+        int flexLineSize = flexboxLayout.getWidth() / 2;
+        TextView textView1 = (TextView) activity.findViewById(R.id.text1);
+        TextView textView2 = (TextView) activity.findViewById(R.id.text2);
+        TextView textView3 = (TextView) activity.findViewById(R.id.text3);
+        assertThat(textView1.getWidth(), not(flexLineSize));
+        assertThat(textView2.getWidth(), isEqualAllowingError(flexLineSize));
+        assertThat(textView3.getWidth(), not(flexLineSize));
+    }
+
+    @Test
+    @FlakyTest
+    public void testHeightMatchParent_flexDirection_row() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        FlexboxLayout flexboxLayout = createFlexboxLayout(
+                R.layout.activity_height_match_parent_direction_row_test);
+
+        onView(withId(R.id.text1)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text1)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isRightOf(withId(R.id.text1)));
+        onView(withId(R.id.text3)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text3)).check(isBelow(withId(R.id.text1)));
+        onView(withId(R.id.text3)).check(isBelow(withId(R.id.text2)));
+
+        // There should be 2 flex lines in the layout with the given layout.
+        // Only the second TextView's height is set to match_parent.
+        int flexLineSize = flexboxLayout.getHeight() / 2;
+        TextView textView1 = (TextView) activity.findViewById(R.id.text1);
+        TextView textView2 = (TextView) activity.findViewById(R.id.text2);
+        TextView textView3 = (TextView) activity.findViewById(R.id.text3);
+        assertThat(textView1.getHeight(), not(flexLineSize));
+        assertThat(textView2.getHeight(), isEqualAllowingError(flexLineSize));
+        assertThat(textView3.getHeight(), not(flexLineSize));
+    }
+
+    @Test
+    @FlakyTest
+    public void testHeightMatchParent_flexDirection_column() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        FlexboxLayout flexboxLayout = createFlexboxLayout(
+                R.layout.activity_height_match_parent_direction_column_test);
+
+        onView(withId(R.id.text1)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text1)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isRightOf(withId(R.id.text1)));
+        onView(withId(R.id.text3)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text3)).check(isRightOf(withId(R.id.text2)));
+
+        // There should be 3 flex lines in the layout with the given layout.
+        // Only the second TextView's height is set to match_parent.
+        int flexLineHeight = flexboxLayout.getHeight();
+        TextView textView1 = (TextView) activity.findViewById(R.id.text1);
+        TextView textView2 = (TextView) activity.findViewById(R.id.text2);
+        TextView textView3 = (TextView) activity.findViewById(R.id.text3);
+        assertThat(textView1.getHeight(), not(flexLineHeight));
+        assertThat(textView2.getHeight(), isEqualAllowingError(flexLineHeight));
+        assertThat(textView3.getHeight(), not(flexLineHeight));
+    }
+
+    @Test
+    @FlakyTest
     public void testAlignItems_flexStart() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
         FlexboxLayout flexboxLayout = createFlexboxLayout(R.layout.activity_align_items_test);

--- a/flexbox/src/androidTest/res/layout/activity_height_match_parent_direction_column_test.xml
+++ b/flexbox/src/androidTest/res/layout/activity_height_match_parent_direction_column_test.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2016 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<com.google.android.flexbox.FlexboxLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="320dp"
+    android:layout_height="320dp"
+    app:alignContent="stretch"
+    app:alignItems="flex_start"
+    app:flexDirection="column"
+    app:flexWrap="wrap">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:text="1"/>
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="120dp"
+        android:layout_height="match_parent"
+        android:text="2"/>
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:text="3"/>
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/androidTest/res/layout/activity_height_match_parent_direction_row_test.xml
+++ b/flexbox/src/androidTest/res/layout/activity_height_match_parent_direction_row_test.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2016 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<com.google.android.flexbox.FlexboxLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="320dp"
+    android:layout_height="320dp"
+    app:alignContent="stretch"
+    app:alignItems="flex_start"
+    app:flexDirection="row"
+    app:flexWrap="wrap">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:text="1"/>
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="120dp"
+        android:layout_height="match_parent"
+        android:text="2"/>
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:text="3"/>
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/androidTest/res/layout/activity_width_match_parent_direction_column_test.xml
+++ b/flexbox/src/androidTest/res/layout/activity_width_match_parent_direction_column_test.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2016 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<com.google.android.flexbox.FlexboxLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="320dp"
+    android:layout_height="320dp"
+    app:alignContent="stretch"
+    app:alignItems="flex_start"
+    app:flexDirection="column"
+    app:flexWrap="wrap">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:text="1"/>
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="match_parent"
+        android:layout_height="120dp"
+        android:text="2"/>
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:text="3"/>
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/androidTest/res/layout/activity_width_match_parent_direction_row_test.xml
+++ b/flexbox/src/androidTest/res/layout/activity_width_match_parent_direction_row_test.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2016 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<com.google.android.flexbox.FlexboxLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="320dp"
+    android:layout_height="320dp"
+    app:alignContent="stretch"
+    app:alignItems="flex_start"
+    app:flexDirection="row"
+    app:flexWrap="wrap">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:text="1"/>
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="match_parent"
+        android:layout_height="120dp"
+        android:text="2"/>
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:text="3"/>
+</com.google.android.flexbox.FlexboxLayout>


### PR DESCRIPTION
With this commit match_parent attribute when set in the cross axis behave exactly like align self stretch.
All the measuring are done with wrap_content instead until the stretching.
It uses the same variable FlexLine.mIndicesAlignSelfStretch to achieve that so I think this name is obsolete and should be renamed to mIndicesToStretch, what do you think?

Also this commit addresses an issue when there are more than one line, the size in the cross axis of one line is more than the next line, and in the next line the first flex item is set to stretch, then the flex item will be stretched to the size of the previous flex line instead of its own line.