### PR TITLE
Fix the scrollToPosition #206

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
@@ -54,7 +54,6 @@ import android.widget.TextView;
 import com.google.android.flexbox.AlignItems;
 import com.google.android.flexbox.AlignSelf;
 import com.google.android.flexbox.FlexDirection;
-import com.google.android.flexbox.FlexLine;
 import com.google.android.flexbox.FlexWrap;
 import com.google.android.flexbox.FlexboxItemDecoration;
 import com.google.android.flexbox.FlexboxLayoutManager;
@@ -2744,6 +2743,94 @@ public class FlexboxLayoutManagerTest {
         assertThat(((TextView) layoutManager.getChildAt(
                 layoutManager.getChildCount() - 1)).getText().toString(),
                 is(String.valueOf(scrollTo + 3)));
+    }
+
+    @Test
+    @FlakyTest
+    public void testScrollToPosition_scrollToNewItem_direction_row() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final TestAdapter adapter = new TestAdapter();
+
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.recyclerview);
+                RecyclerView recyclerView = (RecyclerView) activity.findViewById(R.id.recyclerview);
+                layoutManager.setFlexDirection(FlexDirection.ROW);
+                recyclerView.setLayoutManager(layoutManager);
+                recyclerView.setAdapter(adapter);
+                for (int i = 0; i < 6; i++) {
+                    FlexboxLayoutManager.LayoutParams lp = createLayoutParams(activity, 100, 70);
+                    adapter.addItem(lp);
+                }
+                // There should be 2 lines
+                // RecyclerView width: 320, height: 240.
+                // Flex line 1: 3 items
+                // Flex line 2: 3 items
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        assertThat(layoutManager.getFlexDirection(), is(FlexDirection.ROW));
+
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                FlexboxLayoutManager.LayoutParams lp = createLayoutParams(activity, 100, 70);
+                adapter.addItem(lp);
+                layoutManager.scrollToPosition(adapter.getItemCount() - 1);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // ChildCount (visible views) should be 6 + 1,
+        // which before fixing https://github.com/google/flexbox-layout/issues/206, only the new
+        // item was visible
+        assertThat(layoutManager.getChildCount(), is(7));
+    }
+
+    @Test
+    @FlakyTest
+    public void testScrollToPosition_scrollToNewItem_direction_column() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final TestAdapter adapter = new TestAdapter();
+
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.recyclerview);
+                RecyclerView recyclerView = (RecyclerView) activity.findViewById(R.id.recyclerview);
+                layoutManager.setFlexDirection(FlexDirection.COLUMN);
+                recyclerView.setLayoutManager(layoutManager);
+                recyclerView.setAdapter(adapter);
+                for (int i = 0; i < 6; i++) {
+                    FlexboxLayoutManager.LayoutParams lp = createLayoutParams(activity, 100, 70);
+                    adapter.addItem(lp);
+                }
+                // There should be 2 lines
+                // RecyclerView width: 320, height: 240.
+                // Flex line 1: 3 items
+                // Flex line 2: 3 items
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        assertThat(layoutManager.getFlexDirection(), is(FlexDirection.COLUMN));
+
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                FlexboxLayoutManager.LayoutParams lp = createLayoutParams(activity, 100, 70);
+                adapter.addItem(lp);
+                layoutManager.scrollToPosition(adapter.getItemCount() - 1);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // ChildCount (visible views) should be 6 + 1,
+        // which before fixing https://github.com/google/flexbox-layout/issues/206, only the new
+        // item was visible
+        assertThat(layoutManager.getChildCount(), is(7));
     }
 
     /**

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/TestAdapter.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/TestAdapter.java
@@ -16,13 +16,13 @@
 
 package com.google.android.flexbox.test;
 
-import com.google.android.flexbox.FlexboxLayoutManager;
-
 import android.support.v7.widget.RecyclerView;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+
+import com.google.android.flexbox.FlexboxLayoutManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,7 +38,7 @@ class TestAdapter extends RecyclerView.Adapter<TestViewHolder> {
         this(new ArrayList<FlexboxLayoutManager.LayoutParams>());
     }
 
-    TestAdapter(List<FlexboxLayoutManager.LayoutParams> flexItems) {
+    private TestAdapter(List<FlexboxLayoutManager.LayoutParams> flexItems) {
         mLayoutParams = flexItems;
     }
 
@@ -57,18 +57,11 @@ class TestAdapter extends RecyclerView.Adapter<TestViewHolder> {
         holder.mTextView.setLayoutParams(mLayoutParams.get(position));
     }
 
-    public void addItem(FlexboxLayoutManager.LayoutParams flexItem) {
+    void addItem(FlexboxLayoutManager.LayoutParams flexItem) {
         mLayoutParams.add(flexItem);
     }
 
-    public void removeItem(int position) {
-        if (position < 0 || position >= mLayoutParams.size()) {
-            return;
-        }
-        mLayoutParams.remove(position);
-    }
-
-    public FlexboxLayoutManager.LayoutParams getItemAt(int index) {
+    FlexboxLayoutManager.LayoutParams getItemAt(int index) {
         return mLayoutParams.get(index);
     }
 


### PR DESCRIPTION
This PR fixes the issue #206.
The issue happend because after scrollToPosition is called, the item
specified as the argument is always placed at the first line.
To fix the issue, the gap toward both directions (start and end) needs
to be filled like LinearLayoutManager does.

Note that predictiveAnimation is not supported yet, so a new line or disappearing views are going to appear or disappear within the visible area of the screen instead of shifting from (or shifting to) the screen boundary.