### PR TITLE
Fixes the wrap_content behavior with nested RecyclerViews.

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
@@ -47,6 +47,7 @@ import android.support.test.filters.MediumTest;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.support.v4.content.res.ResourcesCompat;
+import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.view.ViewGroup;
@@ -2893,6 +2894,60 @@ public class FlexboxLayoutManagerTest {
         // https://github.com/google/flexbox-layout/issues/228, the first line disappeared.
         firstView = layoutManager.getChildAt(0);
         assertThat(((TextView) firstView).getText().toString(), is("1"));
+    }
+
+    @Test
+    @FlakyTest
+    public void testNestedRecyclerViews_direction_row() throws Throwable {
+        // This test verifies the nested RecyclerViews.
+        // The outer RecyclerView scrolls vertical using LinearLayoutManager.
+        // The inner RecyclerViews use FlexboxLayoutManager with flexDirection == ROW and
+        // height of the RecyclerView is set to "wrap_content", which before fixing
+        // https://github.com/google/flexbox-layout/issues/208, the height of the inner
+        // RecyclerViews were set to 0.
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        final LinearLayoutManager outerLayoutManager = new LinearLayoutManager(activity);
+        final NestedOuterAdapter adapter = new NestedOuterAdapter(FlexDirection.ROW);
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.recyclerview);
+                RecyclerView recyclerView = (RecyclerView) activity.findViewById(R.id.recyclerview);
+                outerLayoutManager.setOrientation(LinearLayoutManager.VERTICAL);
+                recyclerView.setLayoutManager(outerLayoutManager);
+                recyclerView.setAdapter(adapter);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        NestedOuterAdapter.OuterViewHolder viewHolder = adapter.getViewHolder(0);
+        assertThat(viewHolder.mInnerRecyclerView.getHeight(), is(not(0)));
+    }
+
+    @Test
+    @FlakyTest
+    public void testNestedRecyclerViews_direction_column() throws Throwable {
+        // This test verifies the nested RecyclerViews.
+        // The outer RecyclerView scrolls horizontally using LinearLayoutManager.
+        // The inner RecyclerViews use FlexboxLayoutManager with flexDirection == COLUMN and
+        // width of the RecyclerView is set to "wrap_content", which before fixing
+        // https://github.com/google/flexbox-layout/issues/208, the width of the inner
+        // RecyclerViews were set to 0.
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        final LinearLayoutManager outerLayoutManager = new LinearLayoutManager(activity);
+        final NestedOuterAdapter adapter = new NestedOuterAdapter(FlexDirection.COLUMN);
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.recyclerview);
+                RecyclerView recyclerView = (RecyclerView) activity.findViewById(R.id.recyclerview);
+                outerLayoutManager.setOrientation(LinearLayoutManager.HORIZONTAL);
+                recyclerView.setLayoutManager(outerLayoutManager);
+                recyclerView.setAdapter(adapter);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        NestedOuterAdapter.OuterViewHolder viewHolder = adapter.getViewHolder(0);
+        assertThat(viewHolder.mInnerRecyclerView.getWidth(), is(not(0)));
     }
 
     /**

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/NestedInnerAdapter.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/NestedInnerAdapter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.flexbox.test;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+/**
+ * Adapter for the tests for nested RecyclerViews.
+ * This Adapter is used for the inner RecyclerView.
+ */
+class NestedInnerAdapter extends RecyclerView.Adapter<NestedInnerAdapter.InnerViewHolder> {
+
+    private int mInnerPosition;
+
+    NestedInnerAdapter(int innerPosition) {
+        mInnerPosition = innerPosition;
+    }
+
+    @Override
+    public NestedInnerAdapter.InnerViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.viewholder_textview, parent, false);
+        return new InnerViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(InnerViewHolder holder, int position) {
+        holder.mTextView.setText(mInnerPosition + "-" + position);
+    }
+
+    @Override
+    public int getItemCount() {
+        return 5;
+    }
+
+    static class InnerViewHolder extends RecyclerView.ViewHolder {
+
+        TextView mTextView;
+
+        InnerViewHolder(View itemView) {
+            super(itemView);
+
+            mTextView = (TextView) itemView.findViewById(R.id.textview);
+        }
+    }
+}

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/NestedOuterAdapter.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/NestedOuterAdapter.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.flexbox.test;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.google.android.flexbox.FlexDirection;
+import com.google.android.flexbox.FlexboxLayoutManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Adapter for the tests for nested RecyclerViews.
+ * This Adapter is used for the outer RecyclerView.
+ */
+class NestedOuterAdapter extends RecyclerView.Adapter<NestedOuterAdapter.OuterViewHolder> {
+
+    private static final int ITEM_COUNT = 4;
+
+    private final List<OuterViewHolder> mViewHolderList = new ArrayList<>();
+
+    private final int mFlexDirection;
+
+    NestedOuterAdapter(@FlexDirection int flexDirection) {
+        mFlexDirection = flexDirection;
+    }
+
+    @Override
+    public NestedOuterAdapter.OuterViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.viewholder_inner_recyclerview, parent, false);
+        OuterViewHolder holder = new OuterViewHolder(view);
+        mViewHolderList.add(holder);
+        return holder;
+    }
+
+    @Override
+    public void onBindViewHolder(OuterViewHolder holder, int position) {
+        FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        layoutManager.setFlexDirection(mFlexDirection);
+        holder.mInnerRecyclerView.setLayoutManager(layoutManager);
+        holder.mInnerRecyclerView.setAdapter(new NestedInnerAdapter(position));
+    }
+
+    OuterViewHolder getViewHolder(int position) {
+        return mViewHolderList.get(position);
+    }
+
+    @Override
+    public int getItemCount() {
+        return ITEM_COUNT;
+    }
+
+    static class OuterViewHolder extends RecyclerView.ViewHolder {
+
+        RecyclerView mInnerRecyclerView;
+
+        OuterViewHolder(View itemView) {
+            super(itemView);
+
+            mInnerRecyclerView = (RecyclerView) itemView.findViewById(R.id.recyclerview_inner);
+        }
+    }
+}

--- a/flexbox/src/androidTest/res/layout/viewholder_inner_recyclerview.xml
+++ b/flexbox/src/androidTest/res/layout/viewholder_inner_recyclerview.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2017 Google Inc. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!-- The nested RecyclerViews tests verify the wrap_content behavior -->
+<android.support.v7.widget.RecyclerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/recyclerview_inner"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="8dp" />

--- a/flexbox/src/androidTest/res/layout/viewholder_textview.xml
+++ b/flexbox/src/androidTest/res/layout/viewholder_textview.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2017 Google Inc. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/textview"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_margin="4dp" />


### PR DESCRIPTION
This PR fixes the height (or width if flexDirection == COLUMN) of nested
RecyclerViews.
Before this PR, the height (or width if flexDirection == COLUMN) of the
RecyclerView was set to 0 where RecyclerView is wrapped with another
scrollable container (another RecyclerView or ScrollView) on the condition
layout_height="wrap_content" and flexDirection="row".
In such a case, the height of the inner RecyclerView
(attached RecyclerView for this LayoutManager) is set to 0.

Fixes #208.