### PR TITLE
Support RecycledViewPool and introduce LayoutManager level view cache.

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/FakeFlexContainer.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/FakeFlexContainer.java
@@ -229,4 +229,9 @@ class FakeFlexContainer implements FlexContainer {
     public List<FlexLine> getFlexLinesInternal() {
         return mFlexLines;
     }
+
+    @Override
+    public void updateViewCache(int position, View view) {
+        // No op
+    }
 }

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexContainer.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexContainer.java
@@ -173,7 +173,6 @@ interface FlexContainer {
      * @param view            the view from which the length of the decoration is retrieved
      * @param index           the absolute index of the flex item within the flex container
      * @param indexInFlexLine the relative index of the flex item within the flex line
-     *
      * @return the length of the decoration. Note that the length of the flex item itself is not
      * included in the result.
      */
@@ -182,8 +181,7 @@ interface FlexContainer {
     /**
      * Returns the length of decoration (such as dividers) of the flex item along the cross axis.
      *
-     * @param view            the view from which the length of the decoration is retrieved
-     *
+     * @param view the view from which the length of the decoration is retrieved
      * @return the length of the decoration. Note that the length of the flex item itself is not
      * included in the result.
      */
@@ -278,4 +276,12 @@ interface FlexContainer {
      * in the {@link FlexContainer#getFlexLines()}.
      */
     List<FlexLine> getFlexLinesInternal();
+
+    /**
+     * Update the view cache in the flex container.
+     *
+     * @param position the position of the view to be updated
+     * @param view     the view instance
+     */
+    void updateViewCache(int position, View view);
 }

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
@@ -455,6 +455,7 @@ class FlexboxHelper {
                 child.measure(childCrossMeasureSpec, childMainMeasureSpec);
                 updateMeasureCache(i, childCrossMeasureSpec, childMainMeasureSpec, child);
             }
+            mFlexContainer.updateViewCache(i, child);
 
             // Check the size constraint after the first measurement for the child
             // To prevent the child's width/height violate the size constraints imposed by the
@@ -810,6 +811,7 @@ class FlexboxHelper {
                     .makeMeasureSpec(childHeight, View.MeasureSpec.EXACTLY);
             view.measure(widthSpec, heightSpec);
             updateMeasureCache(index, widthSpec, heightSpec, view);
+            mFlexContainer.updateViewCache(index, view);
         }
     }
 
@@ -1005,6 +1007,7 @@ class FlexboxHelper {
                     childMeasuredHeight = child.getMeasuredHeight();
                     updateMeasureCache(childIndex, childWidthMeasureSpec, childHeightMeasureSpec,
                             child);
+                    mFlexContainer.updateViewCache(childIndex, child);
                 }
                 largestCrossSize = Math.max(largestCrossSize, childMeasuredHeight
                         + flexItem.getMarginTop() + flexItem.getMarginBottom()
@@ -1068,6 +1071,7 @@ class FlexboxHelper {
                     childMeasuredHeight = child.getMeasuredHeight();
                     updateMeasureCache(childIndex, childWidthMeasureSpec, childHeightMeasureSpec,
                             child);
+                    mFlexContainer.updateViewCache(childIndex, child);
                 }
                 largestCrossSize = Math.max(largestCrossSize, childMeasuredWidth
                         + flexItem.getMarginLeft() + flexItem.getMarginRight()
@@ -1198,6 +1202,7 @@ class FlexboxHelper {
                     childMeasuredHeight = child.getMeasuredHeight();
                     updateMeasureCache(childIndex, childWidthMeasureSpec, childHeightMeasureSpec,
                             child);
+                    mFlexContainer.updateViewCache(childIndex, child);
                 }
                 largestCrossSize = Math.max(largestCrossSize, childMeasuredHeight +
                         flexItem.getMarginTop() + flexItem.getMarginBottom() +
@@ -1257,6 +1262,7 @@ class FlexboxHelper {
                     childMeasuredHeight = child.getMeasuredHeight();
                     updateMeasureCache(childIndex, childWidthMeasureSpec, childHeightMeasureSpec,
                             child);
+                    mFlexContainer.updateViewCache(childIndex, child);
                 }
                 largestCrossSize = Math.max(largestCrossSize, childMeasuredWidth +
                         flexItem.getMarginLeft() + flexItem.getMarginRight() +
@@ -1574,6 +1580,7 @@ class FlexboxHelper {
         view.measure(childWidthSpec, childHeightSpec);
 
         updateMeasureCache(index, childWidthSpec, childHeightSpec, view);
+        mFlexContainer.updateViewCache(index, view);
     }
 
     /**
@@ -1607,6 +1614,7 @@ class FlexboxHelper {
         view.measure(childWidthSpec, childHeightSpec);
 
         updateMeasureCache(index, childWidthSpec, childHeightSpec, view);
+        mFlexContainer.updateViewCache(index, view);
     }
 
     /**

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
@@ -1271,6 +1271,11 @@ public class FlexboxLayout extends ViewGroup implements FlexContainer {
         return mFlexLines;
     }
 
+    @Override
+    public void updateViewCache(int position, View view) {
+        // No op
+    }
+
     /**
      * @return the horizontal divider drawable that will divide each item.
      * @see #setDividerDrawable(Drawable)


### PR DESCRIPTION
- By calling setRecycleChildrenOnDetach(true), now views within
  FlexboxLayoutManager is recycled using RecycledViewPool if used with
  multipel RecyclerViews.

- Introduce the LayoutManager level view cache to avoid the same view is
  created multiple times within a same layout pass (onLayoutChildren or
  a scroll method)