### PR TITLE
Fix the alignContent behavior.

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
@@ -1624,6 +1624,110 @@ public class FlexboxAndroidTest {
 
     @Test
     @FlakyTest
+    public void testAlignContent_flexEnd_wrapReverse_contentOverflowed() throws Throwable {
+        FlexboxLayout flexboxLayout =
+                createFlexboxLayout(R.layout.activity_align_content_test_overflowed,
+                        new Configuration() {
+                            @Override
+                            public void apply(FlexboxLayout flexboxLayout) {
+                                flexboxLayout.setAlignContent(FlexboxLayout.ALIGN_CONTENT_FLEX_END);
+                                flexboxLayout.setFlexWrap(FlexboxLayout.FLEX_WRAP_WRAP_REVERSE);
+                            }
+                        });
+        assertThat(flexboxLayout.getAlignContent(), is(FlexboxLayout.ALIGN_CONTENT_FLEX_END));
+        onView(withId(R.id.text6)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text5)).check(isLeftOf(withId(R.id.text6)));
+        onView(withId(R.id.text4)).check(isBelow(withId(R.id.text6)));
+    }
+
+    @Test
+    @FlakyTest
+    public void testAlignContent_flexStart_wrapReverse_contentOverflowed() throws Throwable {
+        FlexboxLayout flexboxLayout =
+                createFlexboxLayout(R.layout.activity_align_content_test_overflowed,
+                        new Configuration() {
+                            @Override
+                            public void apply(FlexboxLayout flexboxLayout) {
+                                flexboxLayout.setAlignContent(
+                                        FlexboxLayout.ALIGN_CONTENT_FLEX_START);
+                                flexboxLayout.setFlexWrap(FlexboxLayout.FLEX_WRAP_WRAP_REVERSE);
+                            }
+                        });
+        assertThat(flexboxLayout.getAlignContent(), is(FlexboxLayout.ALIGN_CONTENT_FLEX_START));
+        onView(withId(R.id.text1)).check(isBottomAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isRightOf(withId(R.id.text1)));
+        onView(withId(R.id.text3)).check(isAbove(withId(R.id.text1)));
+    }
+
+    @Test
+    @FlakyTest
+    public void testAlignContent_spaceBetween_wrapReverse_contentOverflowed() throws Throwable {
+        FlexboxLayout flexboxLayout =
+                createFlexboxLayout(R.layout.activity_align_content_test_overflowed,
+                        new Configuration() {
+                            @Override
+                            public void apply(FlexboxLayout flexboxLayout) {
+                                flexboxLayout.setAlignContent(
+                                        FlexboxLayout.ALIGN_CONTENT_SPACE_BETWEEN);
+                                flexboxLayout.setFlexWrap(FlexboxLayout.FLEX_WRAP_WRAP_REVERSE);
+                            }
+                        });
+        assertThat(flexboxLayout.getAlignContent(), is(FlexboxLayout.ALIGN_CONTENT_SPACE_BETWEEN));
+        onView(withId(R.id.text1)).check(isBottomAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isRightOf(withId(R.id.text1)));
+        onView(withId(R.id.text3)).check(isAbove(withId(R.id.text1)));
+    }
+
+    @Test
+    @FlakyTest
+    public void testAlignContent_center_wrapReverse_contentOverflowed() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        FlexboxLayout flexboxLayout =
+                createFlexboxLayout(R.layout.activity_align_content_test_overflowed,
+                        new Configuration() {
+                            @Override
+                            public void apply(FlexboxLayout flexboxLayout) {
+                                flexboxLayout.setAlignContent(
+                                        FlexboxLayout.ALIGN_CONTENT_CENTER);
+                                flexboxLayout.setFlexWrap(FlexboxLayout.FLEX_WRAP_WRAP_REVERSE);
+                            }
+                        });
+        assertThat(flexboxLayout.getAlignContent(), is(FlexboxLayout.ALIGN_CONTENT_CENTER));
+        TextView textView6 = (TextView) activity.findViewById(R.id.text6);
+        TextView textView4 = (TextView) activity.findViewById(R.id.text4);
+        TextView textView2 = (TextView) activity.findViewById(R.id.text2);
+
+        assertThat(textView6.getTop() - flexboxLayout.getTop(), isEqualAllowingError(
+                (flexboxLayout.getHeight() - textView6.getHeight() - textView4.getHeight()
+                        - textView2.getHeight()) / 2));
+    }
+
+    @Test
+    @FlakyTest
+    public void testAlignContent_spaceAround_wrapReverse_contentOverflowed() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        FlexboxLayout flexboxLayout =
+                createFlexboxLayout(R.layout.activity_align_content_test_overflowed,
+                        new Configuration() {
+                            @Override
+                            public void apply(FlexboxLayout flexboxLayout) {
+                                flexboxLayout.setAlignContent(
+                                        FlexboxLayout.ALIGN_CONTENT_SPACE_AROUND);
+                                flexboxLayout.setFlexWrap(FlexboxLayout.FLEX_WRAP_WRAP_REVERSE);
+                            }
+                        });
+        assertThat(flexboxLayout.getAlignContent(), is(FlexboxLayout.ALIGN_CONTENT_SPACE_AROUND));
+        TextView textView6 = (TextView) activity.findViewById(R.id.text6);
+        TextView textView4 = (TextView) activity.findViewById(R.id.text4);
+        TextView textView2 = (TextView) activity.findViewById(R.id.text2);
+
+        assertThat(textView6.getTop() - flexboxLayout.getTop(), isEqualAllowingError(
+                (flexboxLayout.getHeight() - textView6.getHeight() - textView4.getHeight()
+                        - textView2.getHeight()) / 2));
+    }
+
+    @Test
+    @FlakyTest
     public void testAlignItems_stretch() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
         FlexboxLayout flexboxLayout = createFlexboxLayout(R.layout.activity_stretch_test);
@@ -2509,7 +2613,8 @@ public class FlexboxAndroidTest {
     @FlakyTest
     public void testView_visibility_gone_first_item_in_flex_line_vertical() throws Throwable {
         // This test verifies if the FlexboxLayout is visible when the visibility of the first
-        // flex item in the second flex line (or arbitrary flex lines other than the first flex line)
+        // flex item in the second flex line (or arbitrary flex lines other than the first flex
+        // line)
         // is set to "gone"
         // There was an issue reported for that
         // https://github.com/google/flexbox-layout/issues/47

--- a/flexbox/src/androidTest/res/layout/activity_align_content_test_overflowed.xml
+++ b/flexbox/src/androidTest/res/layout/activity_align_content_test_overflowed.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2016 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="320dp"
+    android:layout_height="320dp"
+    app:flexDirection="row"
+    app:flexWrap="wrap_reverse"
+    app:alignContent="stretch">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:text="1" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:text="2" />
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:text="3" />
+
+    <TextView
+        android:id="@+id/text4"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:text="4" />
+
+    <TextView
+        android:id="@+id/text5"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:text="5" />
+
+    <TextView
+        android:id="@+id/text6"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:text="6" />
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/androidTest/res/layout/activity_align_content_test_overflowed.xml
+++ b/flexbox/src/androidTest/res/layout/activity_align_content_test_overflowed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  Copyright 2016 Google Inc. All rights reserved.
+  Copyright 2017 Google Inc. All rights reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
@@ -1262,9 +1262,12 @@ public class FlexboxLayout extends ViewGroup {
             if (mFlexLines.size() == 1) {
                 mFlexLines.get(0).mCrossSize = size - paddingAlongCrossAxis;
                 // alignContent property is valid only if the Flexbox has at least two lines
-            } else if (mFlexLines.size() >= 2 && totalCrossSize < size) {
+            } else if (mFlexLines.size() >= 2) {
                 switch (mAlignContent) {
                     case ALIGN_CONTENT_STRETCH: {
+                        if (totalCrossSize >= size) {
+                            break;
+                        }
                         float freeSpaceUnit = (size - totalCrossSize) / (float) mFlexLines.size();
                         float accumulatedError = 0;
                         for (int i = 0, flexLinesSize = mFlexLines.size(); i < flexLinesSize; i++) {
@@ -1288,6 +1291,13 @@ public class FlexboxLayout extends ViewGroup {
                         break;
                     }
                     case ALIGN_CONTENT_SPACE_AROUND: {
+                        if (totalCrossSize >= size) {
+                            // If the size of the content is larger than the flex container, the
+                            // Flex lines should be aligned center like ALIGN_CONTENT_CENTER
+                            mFlexLines = constructFlexLinesForAlignContentCenter(size,
+                                    totalCrossSize);
+                            break;
+                        }
                         // The value of free space along the cross axis which needs to be put on top
                         // and below the bottom of each flex line.
                         int spaceTopAndBottom = size - totalCrossSize;
@@ -1306,6 +1316,9 @@ public class FlexboxLayout extends ViewGroup {
                         break;
                     }
                     case ALIGN_CONTENT_SPACE_BETWEEN: {
+                        if (totalCrossSize >= size) {
+                            break;
+                        }
                         // The value of free space along the cross axis between each flex line.
                         float spaceBetweenFlexLine = size - totalCrossSize;
                         int numberOfSpaces = mFlexLines.size() - 1;
@@ -1344,22 +1357,7 @@ public class FlexboxLayout extends ViewGroup {
                         break;
                     }
                     case ALIGN_CONTENT_CENTER: {
-                        int spaceAboveAndBottom = size - totalCrossSize;
-                        spaceAboveAndBottom = spaceAboveAndBottom / 2;
-                        List<FlexLine> newFlexLines = new ArrayList<>();
-                        FlexLine dummySpaceFlexLine = new FlexLine();
-                        dummySpaceFlexLine.mCrossSize = spaceAboveAndBottom;
-                        for (int i = 0, flexLineSize = mFlexLines.size(); i < flexLineSize; i++) {
-                            if (i == 0) {
-                                newFlexLines.add(dummySpaceFlexLine);
-                            }
-                            FlexLine flexLine = mFlexLines.get(i);
-                            newFlexLines.add(flexLine);
-                            if (i == mFlexLines.size() - 1) {
-                                newFlexLines.add(dummySpaceFlexLine);
-                            }
-                        }
-                        mFlexLines = newFlexLines;
+                        mFlexLines = constructFlexLinesForAlignContentCenter(size, totalCrossSize);
                         break;
                     }
                     case ALIGN_CONTENT_FLEX_END: {
@@ -1372,6 +1370,25 @@ public class FlexboxLayout extends ViewGroup {
                 }
             }
         }
+    }
+
+    private List<FlexLine> constructFlexLinesForAlignContentCenter(int size, int totalCrossSize) {
+        int spaceAboveAndBottom = size - totalCrossSize;
+        spaceAboveAndBottom = spaceAboveAndBottom / 2;
+        List<FlexLine> newFlexLines = new ArrayList<>();
+        FlexLine dummySpaceFlexLine = new FlexLine();
+        dummySpaceFlexLine.mCrossSize = spaceAboveAndBottom;
+        for (int i = 0, flexLineSize = mFlexLines.size(); i < flexLineSize; i++) {
+            if (i == 0) {
+                newFlexLines.add(dummySpaceFlexLine);
+            }
+            FlexLine flexLine = mFlexLines.get(i);
+            newFlexLines.add(flexLine);
+            if (i == mFlexLines.size() - 1) {
+                newFlexLines.add(dummySpaceFlexLine);
+            }
+        }
+        return newFlexLines;
     }
 
     /**


### PR DESCRIPTION
Fix the alignContent behavior in the following conditions.
- alignContent is set to flex_end
- The size of the content is larger than the flex container
- flexWrap is set to wrap_reverse

When these conditions are met, the last of the flex item should be
aligned to the top of the flex container, but the first item was aligned
to the bottom of the container instead.

Also fixes other values for alignContent
(center, space_around, space_between) to be Flexbox specification
compliant.

Fixes #250.