### PR TITLE
Fix the case child needs to be measured twice in the initial calculation (measureHorizontal/measureVertical).

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
@@ -17,13 +17,27 @@
 package com.google.android.flexbox.test;
 
 
-import com.google.android.flexbox.FlexboxLayout;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.PositionAssertions.isAbove;
+import static android.support.test.espresso.assertion.PositionAssertions.isBelow;
+import static android.support.test.espresso.assertion.PositionAssertions.isBottomAlignedWith;
+import static android.support.test.espresso.assertion.PositionAssertions.isLeftAlignedWith;
+import static android.support.test.espresso.assertion.PositionAssertions.isLeftOf;
+import static android.support.test.espresso.assertion.PositionAssertions.isRightAlignedWith;
+import static android.support.test.espresso.assertion.PositionAssertions.isRightOf;
+import static android.support.test.espresso.assertion.PositionAssertions.isTopAlignedWith;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
 
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeMatcher;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import static com.google.android.flexbox.test.IsEqualAllowingError.isEqualAllowingError;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
@@ -39,24 +53,13 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.assertion.PositionAssertions.isAbove;
-import static android.support.test.espresso.assertion.PositionAssertions.isBelow;
-import static android.support.test.espresso.assertion.PositionAssertions.isBottomAlignedWith;
-import static android.support.test.espresso.assertion.PositionAssertions.isLeftAlignedWith;
-import static android.support.test.espresso.assertion.PositionAssertions.isLeftOf;
-import static android.support.test.espresso.assertion.PositionAssertions.isRightAlignedWith;
-import static android.support.test.espresso.assertion.PositionAssertions.isRightOf;
-import static android.support.test.espresso.assertion.PositionAssertions.isTopAlignedWith;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static com.google.android.flexbox.test.IsEqualAllowingError.isEqualAllowingError;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import com.google.android.flexbox.FlexboxLayout;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /**
  * Integration tests for {@link FlexboxLayout}.
@@ -3557,6 +3560,30 @@ public class FlexboxAndroidTest {
         // layout_width for text1: 24dp, layout_marginEnd: 12dp
         assertThat(flexboxLayout.getWidth(),
                 isEqualAllowingError(TestUtil.dpToPixel(mActivityRule.getActivity(), 36)));
+    }
+
+    @Test
+    @FlakyTest
+    public void testChildNeedsRemeasure_row() throws Throwable {
+        createFlexboxLayout(R.layout.activity_child_needs_remeasure_row);
+        onView(withId(R.id.text1)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text1)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isBottomAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text3)).check(isRightAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text3)).check(isBottomAlignedWith(withId(R.id.flexbox_layout)));
+    }
+
+    @Test
+    @FlakyTest
+    public void testChildNeedsRemeasure_column() throws Throwable {
+        createFlexboxLayout(R.layout.activity_child_needs_remeasure_column);
+        onView(withId(R.id.text1)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text1)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isRightAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text3)).check(isRightAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text3)).check(isBottomAlignedWith(withId(R.id.flexbox_layout)));
     }
 
     private FlexboxLayout createFlexboxLayout(@LayoutRes final int activityLayoutResId)

--- a/flexbox/src/androidTest/res/layout/activity_child_needs_remeasure_column.xml
+++ b/flexbox/src/androidTest/res/layout/activity_child_needs_remeasure_column.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2017 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:flexDirection="column"
+    app:flexWrap="wrap"
+    app:alignContent="stretch" >
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="100dp"
+        android:layout_height="wrap_content"
+        android:text="1"
+        app:layout_flexGrow="1.0" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="2"
+        app:layout_wrapBefore="true" />
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="3" />
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/androidTest/res/layout/activity_child_needs_remeasure_row.xml
+++ b/flexbox/src/androidTest/res/layout/activity_child_needs_remeasure_row.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2017 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    app:flexDirection="row"
+    app:flexWrap="wrap"
+    app:alignContent="stretch" >
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="wrap_content"
+        android:layout_height="100dp"
+        android:text="1"
+        app:layout_flexGrow="1.0" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:text="2"
+        app:layout_wrapBefore="true" />
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:text="3" />
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexLine.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexLine.java
@@ -77,6 +77,11 @@ public class FlexLine {
     int mMaxBaseline;
 
     /**
+     * The sum of the cross size used before this flex line.
+     */
+    int mSumCrossSizeBefore;
+
+    /**
      * Store the indices of the children views whose alignSelf property is stretch.
      * The stored indices are the absolute indices including all children in the Flexbox,
      * not the relative indices in this flex line.


### PR DESCRIPTION
This PR fixes the corner case where the cross size of the
child is affected by an appended flex line in which the child being processed is the
first item.
E.g. when the child's layout_width is set to match_parent, the width
of that child needs to be determined taking the total cross size (width, assuming flexDirection="column") used
so far into account. In that case, the width of the child needs to be
measured again. Note that we don't need to judge if the wrapping occurs
because it doesn't change the size along the main axis.

Fixes #236 