### PR TITLE
Fix the issue mOrderCache variable is updated at the difference position

### DIFF
--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
@@ -469,7 +469,7 @@ public class FlexboxLayout extends ViewGroup {
         int i = 0;
         for (Order order : orders) {
             reorderedIndices[i] = order.index;
-            mOrderCache.append(i, order.order);
+            mOrderCache.append(order.index, order.order);
             i++;
         }
         return reorderedIndices;


### PR DESCRIPTION
from the index supposed to be.

This could be an issue that reordering the views doesn't happen.