### PR TITLE
Introduce a dirty flag for flex lines.

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
@@ -3055,6 +3055,118 @@ public class FlexboxLayoutManagerTest {
         assertThat(layoutManager.findLastVisibleItemPosition(), is(49));
     }
 
+    @Test
+    @FlakyTest
+    public void testDrawDirtyFlexLine_direction_row() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final TestAdapter adapter = new TestAdapter();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.recyclerview);
+                RecyclerView recyclerView = (RecyclerView) activity.findViewById(R.id.recyclerview);
+                layoutManager.setFlexDirection(FlexDirection.ROW);
+                recyclerView.setLayoutManager(layoutManager);
+                recyclerView.setAdapter(adapter);
+
+                for (int i = 0; i < 30; i++) {
+                    FlexboxLayoutManager.LayoutParams lp = createLayoutParams(activity, 100, 75);
+                    adapter.addItem(lp);
+                }
+            }
+        });
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.BOTTOM_CENTER,
+                GeneralLocation.TOP_CENTER));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.BOTTOM_CENTER,
+                GeneralLocation.TOP_CENTER));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.BOTTOM_CENTER,
+                GeneralLocation.TOP_CENTER));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.BOTTOM_CENTER,
+                GeneralLocation.TOP_CENTER));
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // First scroll to the bottom, then add a new item that isn't visible at this moment.
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                FlexboxLayoutManager.LayoutParams lp = createLayoutParams(activity, 40, 75);
+                adapter.addItem(0, lp);
+            }
+        });
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.TOP_CENTER,
+                GeneralLocation.BOTTOM_CENTER));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.TOP_CENTER,
+                GeneralLocation.BOTTOM_CENTER));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.TOP_CENTER,
+                GeneralLocation.BOTTOM_CENTER));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.TOP_CENTER,
+                GeneralLocation.BOTTOM_CENTER));
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        View firstVisible = layoutManager.getChildAt(0);
+        assertThat(firstVisible.getWidth(),
+                isEqualAllowingError(TestUtil.dpToPixel(activity, 40)));
+        assertThat(firstVisible.getHeight(),
+                isEqualAllowingError(TestUtil.dpToPixel(activity, 75)));
+    }
+
+    @Test
+    @FlakyTest
+    public void testDrawDirtyFlexLine_direction_column() throws Throwable {
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final TestAdapter adapter = new TestAdapter();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.recyclerview);
+                RecyclerView recyclerView = (RecyclerView) activity.findViewById(R.id.recyclerview);
+                layoutManager.setFlexDirection(FlexDirection.COLUMN);
+                recyclerView.setLayoutManager(layoutManager);
+                recyclerView.setAdapter(adapter);
+
+                for (int i = 0; i < 30; i++) {
+                    FlexboxLayoutManager.LayoutParams lp = createLayoutParams(activity, 100, 75);
+                    adapter.addItem(lp);
+                }
+            }
+        });
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.CENTER_RIGHT,
+                GeneralLocation.CENTER_LEFT));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.CENTER_RIGHT,
+                GeneralLocation.CENTER_LEFT));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.CENTER_RIGHT,
+                GeneralLocation.CENTER_LEFT));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.CENTER_RIGHT,
+                GeneralLocation.CENTER_LEFT));
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // First scroll to the bottom, then add a new item that isn't visible at this moment.
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                FlexboxLayoutManager.LayoutParams lp = createLayoutParams(activity, 100, 120);
+                adapter.addItem(0, lp);
+            }
+        });
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.CENTER_LEFT,
+                GeneralLocation.CENTER_RIGHT));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.CENTER_LEFT,
+                GeneralLocation.CENTER_RIGHT));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.CENTER_LEFT,
+                GeneralLocation.CENTER_RIGHT));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.CENTER_LEFT,
+                GeneralLocation.CENTER_RIGHT));
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        View firstVisible = layoutManager.getChildAt(0);
+        assertThat(firstVisible.getWidth(),
+                isEqualAllowingError(TestUtil.dpToPixel(activity, 100)));
+        assertThat(firstVisible.getHeight(),
+                isEqualAllowingError(TestUtil.dpToPixel(activity, 120)));
+    }
+
     /**
      * Creates a new flex item.
      *

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/TestAdapter.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/TestAdapter.java
@@ -57,8 +57,14 @@ class TestAdapter extends RecyclerView.Adapter<TestViewHolder> {
         holder.mTextView.setLayoutParams(mLayoutParams.get(position));
     }
 
+    void addItem(int position, FlexboxLayoutManager.LayoutParams flexItem) {
+        mLayoutParams.add(position, flexItem);
+        notifyItemInserted(position);
+    }
+
     void addItem(FlexboxLayoutManager.LayoutParams flexItem) {
         mLayoutParams.add(flexItem);
+        notifyItemInserted(mLayoutParams.size() - 1);
     }
 
     FlexboxLayoutManager.LayoutParams getItemAt(int index) {

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexLine.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexLine.java
@@ -98,7 +98,14 @@ public class FlexLine {
      * Indicates whether this flex line instance is in a dirty state (needs to be computed before
      * rendering). This flag is set to true for example an item is added at the position not
      * visible and the position is prior to the position than the first visible position.
-     * In that case, the newly added item and flex line needs to be re-computed.
+     * In that case, the newly added item and flex line needs to be re-computed when the
+     * RecyclerView is scrolled toward start and it's about to be drawn.
+     *
+     * Note that a re-computation is not needed for the case where the dirty flag is set to a
+     * flex line after the last visible position. Because the flex lines after the visible potion
+     * are going to be cleared in the normal layout pass in the onLayoutChildren -> updateFlexLine
+     * method. Thus at the time scrolling to the added position, new flex lines will be computed
+     * anyway.
      */
     boolean mDirty;
 

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexLine.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexLine.java
@@ -95,6 +95,14 @@ public class FlexLine {
     int mLastIndex;
 
     /**
+     * Indicates whether this flex line instance is in a dirty state (needs to be computed before
+     * rendering). This flag is set to true for example an item is added at the position not
+     * visible and the position is prior to the position than the first visible position.
+     * In that case, the newly added item and flex line needs to be re-computed.
+     */
+    boolean mDirty;
+
+    /**
      * @return the distance in pixels from the top edge of this view's parent
      * to the top edge of this FlexLine.
      */

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
@@ -333,6 +333,7 @@ class FlexboxHelper {
                 0, toIndex, existingLines);
     }
 
+
     /**
      * Calculates how many flex lines are needed in the flex container layout by measuring each
      * child.
@@ -824,6 +825,7 @@ class FlexboxHelper {
         flexLine.mSumCrossSizeBefore = usedCrossSizeSoFar;
         mFlexContainer.onNewFlexLineAdded(flexLine);
         flexLine.mLastIndex = viewIndex;
+        flexLine.mDirty = false;
         flexLines.add(flexLine);
     }
 


### PR DESCRIPTION
A dirty flag is used to indicate whether a flex line that holds a dirty
flag needs to be recomputed when it is about to be drawn.

Fixes #262