### PR TITLE
Fix the issue that values of the item decoration is misplaced

### DIFF
--- a/flexbox/src/main/java/com/google/android/flexbox/FlexLine.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexLine.java
@@ -189,6 +189,13 @@ public class FlexLine {
     }
 
     /**
+     * @return the first view's index included in this flex line.
+     */
+    public int getFirstIndex() {
+        return mFirstIndex;
+    }
+
+    /**
      * Updates the position of the flex line from the contained view.
      *
      * @param view             the view contained in this flex line

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxItemDecoration.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxItemDecoration.java
@@ -16,6 +16,8 @@
 
 package com.google.android.flexbox;
 
+import static android.support.v7.widget.RecyclerView.NO_POSITION;
+
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
@@ -112,8 +114,8 @@ public class FlexboxItemDecoration extends RecyclerView.ItemDecoration {
         if (flexLines.size() == 0) {
             return;
         }
-        FlexLine lastLine = flexLines.get(flexLines.size() - 1);
-        if (lastLine.mLastIndex > position) {
+        int flexLineIndex = layoutManager.getPositionToFlexLineIndex(position);
+        if (flexLineIndex == 0) {
             return;
         }
 
@@ -142,7 +144,7 @@ public class FlexboxItemDecoration extends RecyclerView.ItemDecoration {
 
     private void setOffsetAlongMainAxis(Rect outRect, int position,
             FlexboxLayoutManager layoutManager, List<FlexLine> flexLines, int flexDirection) {
-        if (isFirstItemInLine(position, flexLines)) {
+        if (isFirstItemInLine(position, flexLines, layoutManager)) {
             return;
         }
 
@@ -273,13 +275,23 @@ public class FlexboxItemDecoration extends RecyclerView.ItemDecoration {
     /**
      * @return {@code true} if the given position is the first item in a flex line.
      */
-    private boolean isFirstItemInLine(int position, List<FlexLine> flexLines) {
+    private boolean isFirstItemInLine(int position, List<FlexLine> flexLines,
+            FlexboxLayoutManager layoutManager) {
+        int flexLineIndex = layoutManager.getPositionToFlexLineIndex(position);
+        if (flexLineIndex != NO_POSITION &&
+                flexLineIndex < layoutManager.getFlexLinesInternal().size() &&
+                layoutManager.getFlexLinesInternal().get(flexLineIndex).mFirstIndex == position) {
+            return true;
+        }
         if (position == 0) {
             return true;
         }
         if (flexLines.size() == 0) {
             return false;
         }
+        // Check if the position is the "lastIndex + 1" of the last line in case the FlexLine which
+        // has the View, whose index is position is not included in the flexLines. (E.g. flexLines
+        // is being calculated
         FlexLine lastLine = flexLines.get(flexLines.size() - 1);
         return lastLine.mLastIndex == position - 1;
     }

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayoutManager.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayoutManager.java
@@ -1349,8 +1349,10 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
             }
 
             if (layoutState.mLayoutDirection == LayoutState.LAYOUT_END) {
+                calculateItemDecorationsForChild(view, TEMP_RECT);
                 addView(view);
             } else {
+                calculateItemDecorationsForChild(view, TEMP_RECT);
                 addView(view, indexInFlexLine);
                 indexInFlexLine++;
             }
@@ -1471,8 +1473,10 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
             childBottom -= (lp.rightMargin + getBottomDecorationHeight(view));
 
             if (layoutState.mLayoutDirection == LayoutState.LAYOUT_END) {
+                calculateItemDecorationsForChild(view, TEMP_RECT);
                 addView(view);
             } else {
+                calculateItemDecorationsForChild(view, TEMP_RECT);
                 addView(view, indexInFlexLine);
                 indexInFlexLine++;
             }
@@ -2260,6 +2264,16 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
             }
         }
         return null;
+    }
+
+    /**
+     * @param position the index of the view
+     * @return the index of the {@link FlexLine}, which includes the view whose index is passed as
+     *         the position argument.
+     */
+    int getPositionToFlexLineIndex(int position) {
+        assert mFlexboxHelper.mIndexToFlexLine != null;
+        return mFlexboxHelper.mIndexToFlexLine[position];
     }
 
     /**


### PR DESCRIPTION
when the user scrolls the RecyclerView.

This was because of the reasons that:
- FlexboxItemDecoration#isFirstItemInLine wasn't working correctly (it
expected the flex lines only being calculated in the
FlexboxHelper#calculateFlexLines, not expecting the already calculated
flex lines).

- In the layoutFlexLine method in FlexboxLayoutManager,
calculateItemDecorationsForChild needed to be called before added to the
RecyclerView because the view man be created in that method, in that
case calcurated decoration's inset values are not set at the time of
creation.