### PR TITLE
Fix the issue that Payload isn't correctly passed to an Adapter.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         // NOTE: Do not place your application dependencies here; they belong

--- a/demo-playground/src/main/java/com/google/android/flexbox/recyclerview/FlexItemAdapter.java
+++ b/demo-playground/src/main/java/com/google/android/flexbox/recyclerview/FlexItemAdapter.java
@@ -18,7 +18,6 @@ package com.google.android.flexbox.recyclerview;
 
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -29,15 +28,12 @@ import com.google.android.flexbox.FlexItemClickListener;
 import com.google.android.flexbox.FlexboxLayoutManager;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
  * {@link RecyclerView.Adapter} implementation for {@link FlexItemViewHolder}.
  */
 public class FlexItemAdapter extends RecyclerView.Adapter<FlexItemViewHolder> {
-
-    private static final String TAG = "FlexItemAdapter";
 
     private AppCompatActivity mActivity;
 
@@ -56,7 +52,6 @@ public class FlexItemAdapter extends RecyclerView.Adapter<FlexItemViewHolder> {
         View view = LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.viewholder_flex_item, parent, false);
 
-        Log.d(TAG, "onCreateViewHolder. ViewType: " + viewType + ", Inflated view: " + view);
         return new FlexItemViewHolder(view);
     }
 
@@ -68,7 +63,6 @@ public class FlexItemAdapter extends RecyclerView.Adapter<FlexItemViewHolder> {
                 new FlexItemChangedListenerImplRecyclerView(mLayoutManager, this),
                 adapterPosition));
         holder.bindTo(mLayoutParams.get(position));
-        Log.d(TAG, "onBindViewHolder. Holder: " + holder + ", Position: " + position);
     }
 
     public void addItem(FlexboxLayoutManager.LayoutParams lp) {
@@ -86,7 +80,7 @@ public class FlexItemAdapter extends RecyclerView.Adapter<FlexItemViewHolder> {
     }
 
     public List<FlexboxLayoutManager.LayoutParams> getItems() {
-        return Collections.unmodifiableList(mLayoutParams);
+        return new ArrayList<>(mLayoutParams);
     }
 
     @Override

--- a/demo-playground/src/main/java/com/google/android/flexbox/recyclerview/FlexItemAdapter.java
+++ b/demo-playground/src/main/java/com/google/android/flexbox/recyclerview/FlexItemAdapter.java
@@ -16,16 +16,17 @@
 
 package com.google.android.flexbox.recyclerview;
 
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.RecyclerView;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
 import com.google.android.apps.flexbox.R;
 import com.google.android.flexbox.FlexItemChangedListenerImplRecyclerView;
 import com.google.android.flexbox.FlexItemClickListener;
 import com.google.android.flexbox.FlexboxLayoutManager;
-
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.RecyclerView;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -35,6 +36,8 @@ import java.util.List;
  * {@link RecyclerView.Adapter} implementation for {@link FlexItemViewHolder}.
  */
 public class FlexItemAdapter extends RecyclerView.Adapter<FlexItemViewHolder> {
+
+    private static final String TAG = "FlexItemAdapter";
 
     private AppCompatActivity mActivity;
 
@@ -52,6 +55,8 @@ public class FlexItemAdapter extends RecyclerView.Adapter<FlexItemViewHolder> {
     public FlexItemViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View view = LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.viewholder_flex_item, parent, false);
+
+        Log.d(TAG, "onCreateViewHolder. ViewType: " + viewType + ", Inflated view: " + view);
         return new FlexItemViewHolder(view);
     }
 
@@ -63,6 +68,7 @@ public class FlexItemAdapter extends RecyclerView.Adapter<FlexItemViewHolder> {
                 new FlexItemChangedListenerImplRecyclerView(mLayoutManager, this),
                 adapterPosition));
         holder.bindTo(mLayoutParams.get(position));
+        Log.d(TAG, "onBindViewHolder. Holder: " + holder + ", Position: " + position);
     }
 
     public void addItem(FlexboxLayoutManager.LayoutParams lp) {

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
@@ -3360,6 +3360,45 @@ public class FlexboxLayoutManagerTest {
         }
     }
 
+
+    @Test
+    @FlakyTest
+    public void testNotifyItemChange_withPayload() throws Throwable {
+        // This test verifies the payload is correctly passed to the Adapter in the case
+        // that notifying an item with payload
+        // https://github.com/google/flexbox-layout/issues/297
+
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final TestAdapter adapter = new TestAdapter();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.recyclerview);
+                RecyclerView recyclerView = (RecyclerView) activity.findViewById(R.id.recyclerview);
+                layoutManager.setFlexDirection(FlexDirection.COLUMN);
+                recyclerView.setLayoutManager(layoutManager);
+                recyclerView.setAdapter(adapter);
+                FlexboxLayoutManager.LayoutParams lp = createLayoutParams(activity, 100, 70);
+                adapter.addItem(lp);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        assertThat(adapter.getPayloads().size(), is(0));
+
+        final String payload = "payload";
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                adapter.changeItemWithPayload(0, payload);
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        assertThat(adapter.getPayloads().size(), is(1));
+        assertThat((String) adapter.getPayloads().get(0), is(payload));
+    }
+
     /**
      * Creates a new flex item.
      *

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/TestAdapter.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/TestAdapter.java
@@ -25,7 +25,6 @@ import android.view.ViewGroup;
 import com.google.android.flexbox.FlexboxLayoutManager;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -81,7 +80,7 @@ class TestAdapter extends RecyclerView.Adapter<TestViewHolder> {
     }
 
     List<Object> getPayloads() {
-        return Collections.unmodifiableList(mReceivedPayloads);
+        return new ArrayList<>(mReceivedPayloads);
     }
 
     FlexboxLayoutManager.LayoutParams getItemAt(int index) {

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/TestAdapter.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/TestAdapter.java
@@ -25,6 +25,7 @@ import android.view.ViewGroup;
 import com.google.android.flexbox.FlexboxLayoutManager;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -33,6 +34,8 @@ import java.util.List;
 class TestAdapter extends RecyclerView.Adapter<TestViewHolder> {
 
     private List<FlexboxLayoutManager.LayoutParams> mLayoutParams;
+
+    private List<Object> mReceivedPayloads = new ArrayList<>();
 
     TestAdapter() {
         this(new ArrayList<FlexboxLayoutManager.LayoutParams>());
@@ -57,6 +60,12 @@ class TestAdapter extends RecyclerView.Adapter<TestViewHolder> {
         holder.mTextView.setLayoutParams(mLayoutParams.get(position));
     }
 
+    @Override
+    public void onBindViewHolder(TestViewHolder holder, int position, List<Object> payloads) {
+        mReceivedPayloads.addAll(payloads);
+        onBindViewHolder(holder, position);
+    }
+
     void addItem(int position, FlexboxLayoutManager.LayoutParams flexItem) {
         mLayoutParams.add(position, flexItem);
         notifyItemInserted(position);
@@ -65,6 +74,14 @@ class TestAdapter extends RecyclerView.Adapter<TestViewHolder> {
     void addItem(FlexboxLayoutManager.LayoutParams flexItem) {
         mLayoutParams.add(flexItem);
         notifyItemInserted(mLayoutParams.size() - 1);
+    }
+
+    void changeItemWithPayload(int position, Object payload) {
+        notifyItemChanged(position, payload);
+    }
+
+    List<Object> getPayloads() {
+        return Collections.unmodifiableList(mReceivedPayloads);
     }
 
     FlexboxLayoutManager.LayoutParams getItemAt(int index) {

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayoutManager.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayoutManager.java
@@ -407,16 +407,6 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
         if (cachedView != null) {
             return cachedView;
         }
-
-        // Look up from the scrap next if there is a matching recycled view
-        // to avoid the same view holder is created from the adapter again
-        List<RecyclerView.ViewHolder> scrapList = mRecycler.getScrapList();
-        for (int i = 0, scrapCount = scrapList.size(); i < scrapCount; i++) {
-            RecyclerView.ViewHolder viewHolder = scrapList.get(i);
-            if (viewHolder.getAdapterPosition() == index) {
-                return viewHolder.itemView;
-            }
-        }
         return mRecycler.getViewForPosition(index);
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 17 13:26:39 JST 2016
+#Tue Jun 13 19:10:11 JST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
The issue was caused because FlexboxLayoutManager returned a scrapped
view holder when it should be returned through the RecyclerView (it's
also returned from the scrapped views, but additional procedures are
processed, such as passing the payload objects if any,
if returned through the RecyclerView).

Fixes #297 
