### PR TITLE
Fixes the issue that only single line was displayed with nested Recyc…

### DIFF
--- a/demo-cat-gallery/src/main/java/com/google/android/flexbox/apps/catgallery/MainActivity.java
+++ b/demo-cat-gallery/src/main/java/com/google/android/flexbox/apps/catgallery/MainActivity.java
@@ -44,7 +44,7 @@ public class MainActivity extends AppCompatActivity {
         setSupportActionBar(toolbar);
 
         RecyclerView recyclerView = (RecyclerView) findViewById(R.id.recyclerview);
-        FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(this);
         layoutManager.setFlexWrap(FlexWrap.WRAP);
         layoutManager.setFlexDirection(FlexDirection.ROW);
         layoutManager.setAlignItems(AlignItems.STRETCH);

--- a/demo-playground/src/main/java/com/google/android/flexbox/RecyclerViewFragment.java
+++ b/demo-playground/src/main/java/com/google/android/flexbox/RecyclerViewFragment.java
@@ -57,8 +57,8 @@ public class RecyclerViewFragment extends Fragment {
 
         RecyclerView recyclerView = (RecyclerView) view.findViewById(
                 R.id.recyclerview);
-        final FlexboxLayoutManager flexboxLayoutManager = new FlexboxLayoutManager();
         final MainActivity activity = (MainActivity) getActivity();
+        final FlexboxLayoutManager flexboxLayoutManager = new FlexboxLayoutManager(activity);
         recyclerView.setLayoutManager(flexboxLayoutManager);
         if (mAdapter == null) {
             mAdapter = new FlexItemAdapter(activity, flexboxLayoutManager);

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerConfigChangeTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerConfigChangeTest.java
@@ -67,7 +67,7 @@ public class FlexboxLayoutManagerConfigChangeTest {
         // orientation
         // happens with an Activity that handles configuration changes manually
         final ConfigChangeActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
 
         mActivityRule.runOnUiThread(new Runnable() {
@@ -127,7 +127,7 @@ public class FlexboxLayoutManagerConfigChangeTest {
         // orientation
         // happens with an Activity that handles configuration changes manually
         final ConfigChangeActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
 
         mActivityRule.runOnUiThread(new Runnable() {

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
@@ -130,7 +130,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testAddViewHolders_direction_row_not_wrapped() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -158,7 +158,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testAddViewHolders_direction_row_wrapped() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -186,7 +186,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testAddViewHolders_direction_row_partOfItems_detached() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -223,7 +223,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testAddViewHolders_direction_row_scrollVertically() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -269,7 +269,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testFlexGrow() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -308,7 +308,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testAddViewHolders_direction_column_partOfItems_detached() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -347,7 +347,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testAddViewHolders_direction_column_scrollHorizontally() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -395,7 +395,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_flexStart_direction_row() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -437,7 +437,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_flexEnd_direction_row() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -479,7 +479,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_center_direction_row() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -521,7 +521,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_spaceAround_direction_row() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -563,7 +563,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_spaceBetween_direction_row() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -605,7 +605,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_flexStart_direction_rowReverse() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -649,7 +649,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_flexEnd_direction_rowReverse() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -693,7 +693,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_center_direction_rowReverse() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -737,7 +737,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_spaceAround_direction_rowReverse() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -781,7 +781,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_spaceBetween_direction_rowReverse() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -825,7 +825,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_flexStart_direction_column() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -869,7 +869,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_flexEnd_direction_column() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -913,7 +913,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_center_direction_column() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -957,7 +957,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_spaceAround_direction_column() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -1001,7 +1001,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_spaceBetween_direction_column() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -1045,7 +1045,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_flexStart_direction_columnReverse() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -1089,7 +1089,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_flexEnd_direction_columnReverse() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -1133,7 +1133,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_center_direction_columnReverse() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -1177,7 +1177,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_spaceAround_direction_columnReverse() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -1221,7 +1221,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testJustifyContent_spaceBetween_direction_columnReverse() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -1265,7 +1265,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testLargeItem_scrollFast_direction_row() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -1350,7 +1350,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testLargeItem_scrollFast_direction_column() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -1441,7 +1441,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testAlignItems_stretch_direction_row() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -1480,7 +1480,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testAlignItems_stretch_direction_column() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -1519,7 +1519,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testAlignSelf_stretch_direction_row() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -1559,7 +1559,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testAlignSelf_stretch_direction_column() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -1599,7 +1599,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testStretchViews_from_middle_direction_row() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -1650,7 +1650,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testStretchViews_from_middle_direction_column() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -1705,7 +1705,7 @@ public class FlexboxLayoutManagerTest {
         // flex line position (view which has the minimum top position in the same flex line)
         // This test verifies the issue is fixed.
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         final int positionInSecondLine = 6;
         mActivityRule.runOnUiThread(new Runnable() {
@@ -1764,7 +1764,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testScrollToLeft_middleItem_as_anchorPosition() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         final int positionInSecondLine = 6;
         mActivityRule.runOnUiThread(new Runnable() {
@@ -1828,7 +1828,7 @@ public class FlexboxLayoutManagerTest {
         // flex line position (view which has the maximum bottom position in the same flex line)
         // This test verifies the issue is fixed.
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         final int positionInSecondBottomLine = 45;
         mActivityRule.runOnUiThread(new Runnable() {
@@ -1875,7 +1875,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testScrollToTop_direction_rowReverse() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -1923,7 +1923,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testFlexGrow_only_oneItem_has_positive_direction_row() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -1956,7 +1956,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testFlexGrow_only_oneItem_has_positive_direction_column() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -1989,7 +1989,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testFirstReferenceView_middleOf_line_used_as_anchor() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -2047,7 +2047,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testLastReferenceView_middleOf_line_used_as_anchor() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -2098,7 +2098,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testRotateScreen_direction_row() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -2148,7 +2148,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testRotateScreen_direction_column() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -2198,7 +2198,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testDecoration_direction_row() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         final Drawable drawable = ResourcesCompat.getDrawable(activity.getResources(),
                 R.drawable.divider, null);
@@ -2291,7 +2291,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testDecoration_direction_rowReverse() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         final Drawable drawable = ResourcesCompat.getDrawable(activity.getResources(),
                 R.drawable.divider, null);
@@ -2393,7 +2393,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testDecoration_direction_column() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         final Drawable drawable = ResourcesCompat.getDrawable(activity.getResources(),
                 R.drawable.divider, null);
@@ -2486,7 +2486,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testDecoration_direction_columnReverse() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         final Drawable drawable = ResourcesCompat.getDrawable(activity.getResources(),
                 R.drawable.divider, null);
@@ -2588,7 +2588,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testScrollToPosition_direction_row() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
 
         mActivityRule.runOnUiThread(new Runnable() {
@@ -2671,7 +2671,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testScrollToPosition_direction_column() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
 
         mActivityRule.runOnUiThread(new Runnable() {
@@ -2754,7 +2754,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testScrollToPosition_scrollToNewItem_direction_row() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
 
         mActivityRule.runOnUiThread(new Runnable() {
@@ -2798,7 +2798,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testScrollToPosition_scrollToNewItem_direction_column() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
 
         mActivityRule.runOnUiThread(new Runnable() {
@@ -2847,7 +2847,7 @@ public class FlexboxLayoutManagerTest {
         // https://github.com/google/flexbox-layout/issues/228
 
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
 
         mActivityRule.runOnUiThread(new Runnable() {
@@ -2915,8 +2915,8 @@ public class FlexboxLayoutManagerTest {
 
         // Give the inner adapter item count enough so that inner RecyclerView with
         // FlexboxLayoutManager wraps its items
-        int innerAdapterItemCount = 20;
-        final NestedOuterAdapter adapter = new NestedOuterAdapter(FlexDirection.ROW,
+        int innerAdapterItemCount = 500;
+        final NestedOuterAdapter adapter = new NestedOuterAdapter(activity,FlexDirection.ROW,
                 innerAdapterItemCount, R.layout.viewholder_inner_recyclerview);
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -2955,7 +2955,7 @@ public class FlexboxLayoutManagerTest {
         // Give the inner adapter item count enough so that inner RecyclerView with
         // FlexboxLayoutManager wraps its items
         int innerAdapterItemCount = 20;
-        final NestedOuterAdapter adapter = new NestedOuterAdapter(FlexDirection.COLUMN,
+        final NestedOuterAdapter adapter = new NestedOuterAdapter(activity, FlexDirection.COLUMN,
                 innerAdapterItemCount, R.layout.viewholder_inner_recyclerview_wrap_horizontally);
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -2983,7 +2983,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testFindVisibleChild_direction_row() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -3033,7 +3033,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testFindVisibleChild_direction_column() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -3086,7 +3086,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testDrawDirtyFlexLine_direction_row() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -3142,7 +3142,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testDrawDirtyFlexLine_direction_column() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -3198,7 +3198,7 @@ public class FlexboxLayoutManagerTest {
     @FlakyTest
     public void testChildrenSizeWithMargin() throws Throwable {
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
@@ -3244,7 +3244,7 @@ public class FlexboxLayoutManagerTest {
         // https://github.com/google/flexbox-layout/issues/285
 
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         final Drawable decorationDrawable = getDrawable(activity, R.drawable.divider);
         mActivityRule.runOnUiThread(new Runnable() {
@@ -3318,7 +3318,7 @@ public class FlexboxLayoutManagerTest {
         // https://github.com/google/flexbox-layout/issues/285
 
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         final Drawable decorationDrawable = getDrawable(activity, R.drawable.divider);
         mActivityRule.runOnUiThread(new Runnable() {
@@ -3393,7 +3393,7 @@ public class FlexboxLayoutManagerTest {
         // https://github.com/google/flexbox-layout/issues/297
 
         final FlexboxTestActivity activity = mActivityRule.getActivity();
-        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
         final TestAdapter adapter = new TestAdapter();
         mActivityRule.runOnUiThread(new Runnable() {
             @Override

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
@@ -2912,7 +2912,12 @@ public class FlexboxLayoutManagerTest {
         // RecyclerViews were set to 0.
         final FlexboxTestActivity activity = mActivityRule.getActivity();
         final LinearLayoutManager outerLayoutManager = new LinearLayoutManager(activity);
-        final NestedOuterAdapter adapter = new NestedOuterAdapter(FlexDirection.ROW);
+
+        // Give the inner adapter item count enough so that inner RecyclerView with
+        // FlexboxLayoutManager wraps its items
+        int innerAdapterItemCount = 20;
+        final NestedOuterAdapter adapter = new NestedOuterAdapter(FlexDirection.ROW,
+                innerAdapterItemCount, R.layout.viewholder_inner_recyclerview);
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -2925,7 +2930,14 @@ public class FlexboxLayoutManagerTest {
         });
         InstrumentationRegistry.getInstrumentation().waitForIdleSync();
         NestedOuterAdapter.OuterViewHolder viewHolder = adapter.getViewHolder(0);
-        assertThat(viewHolder.mInnerRecyclerView.getHeight(), is(not(0)));
+        RecyclerView innerRecyclerView = viewHolder.mInnerRecyclerView;
+        assertThat(innerRecyclerView.getHeight(), is(not(0)));
+
+        // This assertion verifies that inner RecylerView displays the entire items including
+        // wrapped lines to verify the issue that nested RecyclerView with FlexboxLayoutManager
+        // only displayed one line https://github.com/google/flexbox-layout/issues/290
+        assertThat(((FlexboxLayoutManager)innerRecyclerView
+                .getLayoutManager()).findLastVisibleItemPosition(), is(innerAdapterItemCount - 1));
     }
 
     @Test
@@ -2939,7 +2951,12 @@ public class FlexboxLayoutManagerTest {
         // RecyclerViews were set to 0.
         final FlexboxTestActivity activity = mActivityRule.getActivity();
         final LinearLayoutManager outerLayoutManager = new LinearLayoutManager(activity);
-        final NestedOuterAdapter adapter = new NestedOuterAdapter(FlexDirection.COLUMN);
+
+        // Give the inner adapter item count enough so that inner RecyclerView with
+        // FlexboxLayoutManager wraps its items
+        int innerAdapterItemCount = 20;
+        final NestedOuterAdapter adapter = new NestedOuterAdapter(FlexDirection.COLUMN,
+                innerAdapterItemCount, R.layout.viewholder_inner_recyclerview_wrap_horizontally);
         mActivityRule.runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -2952,7 +2969,14 @@ public class FlexboxLayoutManagerTest {
         });
         InstrumentationRegistry.getInstrumentation().waitForIdleSync();
         NestedOuterAdapter.OuterViewHolder viewHolder = adapter.getViewHolder(0);
-        assertThat(viewHolder.mInnerRecyclerView.getWidth(), is(not(0)));
+        RecyclerView innerRecyclerView = viewHolder.mInnerRecyclerView;
+        assertThat(innerRecyclerView.getWidth(), is(not(0)));
+
+        // This assertion verifies that inner RecylerView displays the entire items including
+        // wrapped lines to verify the issue that nested RecyclerView with FlexboxLayoutManager
+        // only displayed one line https://github.com/google/flexbox-layout/issues/290
+        assertThat(((FlexboxLayoutManager)innerRecyclerView
+                .getLayoutManager()).findLastVisibleItemPosition(), is(innerAdapterItemCount - 1));
     }
 
     @Test

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
@@ -2915,7 +2915,7 @@ public class FlexboxLayoutManagerTest {
 
         // Give the inner adapter item count enough so that inner RecyclerView with
         // FlexboxLayoutManager wraps its items
-        int innerAdapterItemCount = 500;
+        int innerAdapterItemCount = 20;
         final NestedOuterAdapter adapter = new NestedOuterAdapter(activity,FlexDirection.ROW,
                 innerAdapterItemCount, R.layout.viewholder_inner_recyclerview);
         mActivityRule.runOnUiThread(new Runnable() {

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/NestedInnerAdapter.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/NestedInnerAdapter.java
@@ -30,8 +30,11 @@ class NestedInnerAdapter extends RecyclerView.Adapter<NestedInnerAdapter.InnerVi
 
     private int mInnerPosition;
 
-    NestedInnerAdapter(int innerPosition) {
+    private int mItemCount;
+
+    NestedInnerAdapter(int innerPosition, int itemCount) {
         mInnerPosition = innerPosition;
+        mItemCount = itemCount;
     }
 
     @Override
@@ -48,7 +51,7 @@ class NestedInnerAdapter extends RecyclerView.Adapter<NestedInnerAdapter.InnerVi
 
     @Override
     public int getItemCount() {
-        return 5;
+        return mItemCount;
     }
 
     static class InnerViewHolder extends RecyclerView.ViewHolder {

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/NestedOuterAdapter.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/NestedOuterAdapter.java
@@ -16,6 +16,7 @@
 
 package com.google.android.flexbox.test;
 
+import android.content.Context;
 import android.support.annotation.LayoutRes;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -36,6 +37,8 @@ class NestedOuterAdapter extends RecyclerView.Adapter<NestedOuterAdapter.OuterVi
 
     private static final int ITEM_COUNT = 4;
 
+    private final Context mContext;
+
     private final List<OuterViewHolder> mViewHolderList = new ArrayList<>();
 
     private final int mFlexDirection;
@@ -44,8 +47,9 @@ class NestedOuterAdapter extends RecyclerView.Adapter<NestedOuterAdapter.OuterVi
 
     private final int mViewHolderResId;
 
-    NestedOuterAdapter(@FlexDirection int flexDirection, int innerAdapterItemCount,
+    NestedOuterAdapter(Context context, @FlexDirection int flexDirection, int innerAdapterItemCount,
             @LayoutRes int viewHolderResId) {
+        mContext = context;
         mFlexDirection = flexDirection;
         mInnerAdapterItemCount = innerAdapterItemCount;
         mViewHolderResId = viewHolderResId;
@@ -62,7 +66,7 @@ class NestedOuterAdapter extends RecyclerView.Adapter<NestedOuterAdapter.OuterVi
 
     @Override
     public void onBindViewHolder(OuterViewHolder holder, int position) {
-        FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
+        FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(mContext);
         layoutManager.setFlexDirection(mFlexDirection);
         holder.mInnerRecyclerView.setLayoutManager(layoutManager);
         holder.mInnerRecyclerView.setAdapter(new NestedInnerAdapter(position,

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/NestedOuterAdapter.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/NestedOuterAdapter.java
@@ -16,6 +16,7 @@
 
 package com.google.android.flexbox.test;
 
+import android.support.annotation.LayoutRes;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -39,14 +40,21 @@ class NestedOuterAdapter extends RecyclerView.Adapter<NestedOuterAdapter.OuterVi
 
     private final int mFlexDirection;
 
-    NestedOuterAdapter(@FlexDirection int flexDirection) {
+    private final int mInnerAdapterItemCount;
+
+    private final int mViewHolderResId;
+
+    NestedOuterAdapter(@FlexDirection int flexDirection, int innerAdapterItemCount,
+            @LayoutRes int viewHolderResId) {
         mFlexDirection = flexDirection;
+        mInnerAdapterItemCount = innerAdapterItemCount;
+        mViewHolderResId = viewHolderResId;
     }
 
     @Override
     public NestedOuterAdapter.OuterViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View view = LayoutInflater.from(parent.getContext())
-                .inflate(R.layout.viewholder_inner_recyclerview, parent, false);
+                .inflate(mViewHolderResId, parent, false);
         OuterViewHolder holder = new OuterViewHolder(view);
         mViewHolderList.add(holder);
         return holder;
@@ -57,7 +65,8 @@ class NestedOuterAdapter extends RecyclerView.Adapter<NestedOuterAdapter.OuterVi
         FlexboxLayoutManager layoutManager = new FlexboxLayoutManager();
         layoutManager.setFlexDirection(mFlexDirection);
         holder.mInnerRecyclerView.setLayoutManager(layoutManager);
-        holder.mInnerRecyclerView.setAdapter(new NestedInnerAdapter(position));
+        holder.mInnerRecyclerView.setAdapter(new NestedInnerAdapter(position,
+                mInnerAdapterItemCount));
     }
 
     OuterViewHolder getViewHolder(int position) {

--- a/flexbox/src/androidTest/res/layout/viewholder_inner_recyclerview_wrap_horizontally.xml
+++ b/flexbox/src/androidTest/res/layout/viewholder_inner_recyclerview_wrap_horizontally.xml
@@ -17,6 +17,6 @@
 <android.support.v7.widget.RecyclerView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/recyclerview_inner"
-    android:layout_width="200dp"
-    android:layout_height="wrap_content"
+    android:layout_width="wrap_content"
+    android:layout_height="200dp"
     android:layout_marginBottom="8dp" />

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayoutManager.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayoutManager.java
@@ -778,6 +778,7 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
 
         mLastWidth = width;
         mLastHeight = height;
+        int needsToFill = mLayoutState.mInfinite ? Integer.MAX_VALUE : mLayoutState.mAvailable;
         if (mPendingScrollPosition != NO_POSITION || isMainSizeChanged) {
             if (mAnchorInfo.mLayoutFromEnd) {
                 // Prior flex lines should be already calculated, don't have to be updated
@@ -798,11 +799,11 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
             if (isMainAxisDirectionHorizontal()) {
                 flexLinesResult = mFlexboxHelper
                         .calculateHorizontalFlexLinesToIndex(widthMeasureSpec, heightMeasureSpec,
-                                mLayoutState.mAvailable, mAnchorInfo.mPosition, mFlexLines);
+                                needsToFill, mAnchorInfo.mPosition, mFlexLines);
             } else {
                 flexLinesResult = mFlexboxHelper
                         .calculateVerticalFlexLinesToIndex(widthMeasureSpec, heightMeasureSpec,
-                                mLayoutState.mAvailable, mAnchorInfo.mPosition, mFlexLines);
+                                needsToFill, mAnchorInfo.mPosition, mFlexLines);
             }
             mFlexLines = flexLinesResult.mFlexLines;
             mFlexboxHelper.determineMainSize(widthMeasureSpec, heightMeasureSpec);
@@ -823,12 +824,12 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
                     mFlexboxHelper.clearFlexLines(mFlexLines, mAnchorInfo.mPosition);
                     flexLinesResult = mFlexboxHelper
                             .calculateHorizontalFlexLines(widthMeasureSpec, heightMeasureSpec,
-                                    mLayoutState.mAvailable, mAnchorInfo.mPosition, mFlexLines);
+                                    needsToFill, mAnchorInfo.mPosition, mFlexLines);
                 } else {
                     mFlexboxHelper.ensureIndexToFlexLine(childCount);
                     flexLinesResult = mFlexboxHelper
                             .calculateHorizontalFlexLines(widthMeasureSpec, heightMeasureSpec,
-                                    mLayoutState.mAvailable, 0, mFlexLines);
+                                    needsToFill, 0, mFlexLines);
                 }
             } else {
                 if (mFlexLines.size() > 0) {
@@ -837,12 +838,12 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
                     mFlexboxHelper.clearFlexLines(mFlexLines, mAnchorInfo.mPosition);
                     flexLinesResult = mFlexboxHelper
                             .calculateVerticalFlexLines(widthMeasureSpec, heightMeasureSpec,
-                                    mLayoutState.mAvailable, mAnchorInfo.mPosition, mFlexLines);
+                                    needsToFill, mAnchorInfo.mPosition, mFlexLines);
                 } else {
                     mFlexboxHelper.ensureIndexToFlexLine(childCount);
                     flexLinesResult = mFlexboxHelper
                             .calculateVerticalFlexLines(widthMeasureSpec, heightMeasureSpec,
-                                    mLayoutState.mAvailable, 0, mFlexLines);
+                                    needsToFill, 0, mFlexLines);
                 }
             }
             mFlexLines = flexLinesResult.mFlexLines;


### PR DESCRIPTION
…lerViews

where the inner RecycerView's adapter is FlexboxLayoutManager with FlexWrap is
set to wrap.

This was caused because height 0 was passed from the parent RecyclerView
if the layout_height is specified as wrap_content, thus
FlexboxLayoutManager didn't calculate the entire items for its flex lines.

This fixes #290