### PR TITLE
Fixes the issue that the items becoms invisible on the condition that:

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxAndroidTest.java
@@ -3925,6 +3925,66 @@ public class FlexboxAndroidTest {
         onView(withId(R.id.text3)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
     }
 
+    @Test
+    @FlakyTest
+    public void testFirstViewGone_flexGrowSetForRestOfItems_row() throws Throwable {
+        // This test verifies the case where the first view's visibility is gone and the second
+        // view and third view have the layout_flexGrow attribute set. In that case, the second
+        // view's position is misplaced and the third view becomes invisible .
+        // https://github.com/google/flexbox-layout/issues/303
+        createFlexboxLayout(R.layout.activity_first_view_gone_layout_grow_set_for_rest);
+        onView(withId(R.id.text2)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isRightAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text3)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text3)).check(isRightAlignedWith(withId(R.id.flexbox_layout)));
+    }
+
+    @Test
+    @FlakyTest
+    public void testFirstViewGone_flexGrowSetForRestOfItems_column() throws Throwable {
+        // This test verifies the case where the first view's visibility is gone and the second
+        // view and third view have the layout_flexGrow attribute set. In that case, the second
+        // view's position is misplaced and the third view becomes invisible .
+        // https://github.com/google/flexbox-layout/issues/303
+        createFlexboxLayout(R.layout.activity_first_view_gone_layout_grow_set_for_rest,
+                new Configuration() {
+                    @Override
+                    public void apply(FlexboxLayout flexboxLayout) {
+                        flexboxLayout.setFlexDirection(FlexDirection.COLUMN);
+                    }
+                });
+        onView(withId(R.id.text2)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isBottomAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text3)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text3)).check(isBottomAlignedWith(withId(R.id.flexbox_layout)));
+    }
+
+    @Test
+    @FlakyTest
+    public void testFirstViewGone_flexShrinkSetForRestOfItems_row() throws Throwable {
+        createFlexboxLayout(R.layout.activity_first_view_gone_layout_shrink_set_for_rest);
+        onView(withId(R.id.text2)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text3)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+    }
+
+    @Test
+    @FlakyTest
+    public void testFirstViewGone_flexShrinkSetForRestOfItems_column() throws Throwable {
+        createFlexboxLayout(R.layout.activity_first_view_gone_layout_shrink_set_for_rest,
+                new Configuration() {
+                    @Override
+                    public void apply(FlexboxLayout flexboxLayout) {
+                        flexboxLayout.setFlexDirection(FlexDirection.COLUMN);
+                    }
+                });
+        onView(withId(R.id.text2)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text2)).check(isLeftAlignedWith(withId(R.id.flexbox_layout)));
+        onView(withId(R.id.text3)).check(isTopAlignedWith(withId(R.id.flexbox_layout)));
+    }
+
     private FlexboxLayout createFlexboxLayout(@LayoutRes final int activityLayoutResId)
             throws Throwable {
         return createFlexboxLayout(activityLayoutResId, Configuration.EMPTY);

--- a/flexbox/src/androidTest/res/layout/activity_first_view_gone_layout_grow_set_for_rest.xml
+++ b/flexbox/src/androidTest/res/layout/activity_first_view_gone_layout_grow_set_for_rest.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2017 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<!--
+This layout verifies the case where the first view's visibility is gone and the second view is
+in the next flex line by setting the layout_wrapBefore="true"
+-->
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="320dp"
+    android:layout_height="320dp"
+    app:flexDirection="row"
+    app:flexWrap="wrap"
+    app:alignItems="stretch"
+    app:alignContent="stretch">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="60dp"
+        android:layout_height="60dp"
+        android:text="1"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="120dp"
+        android:layout_height="60dp"
+        android:text="2"
+        app:layout_wrapBefore="true"
+        app:layout_flexGrow="1" />
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="100dp"
+        android:layout_height="60dp"
+        android:text="3"
+        app:layout_flexGrow="1"
+        app:layout_wrapBefore="true" />
+</com.google.android.flexbox.FlexboxLayout>

--- a/flexbox/src/androidTest/res/layout/activity_first_view_gone_layout_shrink_set_for_rest.xml
+++ b/flexbox/src/androidTest/res/layout/activity_first_view_gone_layout_shrink_set_for_rest.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2017 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<!--
+This layout verifies the case where the first view's visibility is gone and the second view is
+in the next flex line by setting the layout_wrapBefore="true"
+-->
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/flexbox_layout"
+    android:layout_width="320dp"
+    android:layout_height="320dp"
+    app:flexDirection="row"
+    app:flexWrap="wrap"
+    app:alignItems="stretch"
+    app:alignContent="stretch">
+
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="60dp"
+        android:layout_height="60dp"
+        android:text="1"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/text2"
+        android:layout_width="120dp"
+        android:layout_height="60dp"
+        android:text="2"
+        app:layout_wrapBefore="true"
+        app:layout_flexShrink="1" />
+
+    <TextView
+        android:id="@+id/text3"
+        android:layout_width="100dp"
+        android:layout_height="60dp"
+        android:text="3"
+        app:layout_flexShrink="1"
+        app:layout_wrapBefore="true" />
+</com.google.android.flexbox.FlexboxLayout>


### PR DESCRIPTION
    - the first item's visibility is gone
    - the rest of the items (e.g. three in total) have layout_flexGrow attribute set.
    - the second view has layout_wrapBefore attribute set (no items are
    added to the flex line where the gone view is included)
    
    In that case the index of the views after the gone view is not correctly
    counted in computing flexGrow and flexShrink.
