### PR TITLE
Remove Pixel from the device list.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,7 @@ test:
                 counter=0 ;
                 result=1 ;
                 while [ $result != 0 -a $counter -lt $MAX_RETRY ]; do
-                    gcloud firebase test android run --type instrumentation --app demo-playground/build/outputs/apk/demo-playground-debug.apk --test flexbox/build/outputs/apk/flexbox-debug-androidTest.apk --device-ids hammerhead,herolte,sailfish --os-version-ids 19,21,23,24,25-device-ids hammerhead,flounder,condor_umts --os-version-ids 19,21,23 --locales en --orientations portrait,landscape --results-bucket ${GCLOUD_TEST_BUCKET_LIBRARY} --timeout 180s ;
+                    gcloud firebase test android run --type instrumentation --app demo-playground/build/outputs/apk/demo-playground-debug.apk --test flexbox/build/outputs/apk/flexbox-debug-androidTest.apk --device-ids hammerhead,herolte --os-version-ids 19,21,23,24,25 --locales en --orientations portrait,landscape --results-bucket ${GCLOUD_TEST_BUCKET_LIBRARY} --timeout 180s ;
                     result=$? ;
                     let counter=counter+1 ;
                 done


### PR DESCRIPTION
This is a workaround to fix the continuous ci failures.