### PR TITLE
Implement horizontal scrolling (scroll along the main axis)

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
@@ -3497,6 +3497,94 @@ public class FlexboxLayoutManagerTest {
         assertThat((String) adapter.getPayloads().get(0), is(payload));
     }
 
+    @Test
+    @FlakyTest
+    public void testScrollAlongManAxis_direction_row() throws Throwable {
+        // This test verifies the scroll along the main axis if the width of the RecyclerView is
+        // larger than its parent when the main axis direction is horizontal (row)
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
+        final TestAdapter adapter = new TestAdapter();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.wrapped_recyclerview);
+                RecyclerView recyclerView = (RecyclerView) activity.findViewById(R.id.recyclerview);
+                layoutManager.setFlexDirection(FlexDirection.ROW);
+                recyclerView.setLayoutManager(layoutManager);
+                recyclerView.setAdapter(adapter);
+                for (int i = 0; i < 50; i++) {
+                    FlexboxLayoutManager.LayoutParams lp = createLayoutParams(activity, 100, 70);
+                    adapter.addItem(lp);
+                }
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        assertThat(layoutManager.getChildAt(0).getLeft(), is(0));
+        onView(withId(R.id.container)).perform(swipe(GeneralLocation.CENTER_RIGHT,
+                GeneralLocation.CENTER_LEFT));
+        onView(withId(R.id.container)).perform(swipe(GeneralLocation.CENTER_RIGHT,
+                GeneralLocation.CENTER_LEFT));
+        onView(withId(R.id.container)).perform(swipe(GeneralLocation.CENTER_RIGHT,
+                GeneralLocation.CENTER_LEFT));
+        assertThat(layoutManager.getChildAt(0).getLeft(), is(not(0)));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        onView(withId(R.id.container)).perform(swipe(GeneralLocation.CENTER_LEFT,
+                GeneralLocation.CENTER_RIGHT));
+        onView(withId(R.id.container)).perform(swipe(GeneralLocation.CENTER_LEFT,
+                GeneralLocation.CENTER_RIGHT));
+        onView(withId(R.id.container)).perform(swipe(GeneralLocation.CENTER_LEFT,
+                GeneralLocation.CENTER_RIGHT));
+        onView(withId(R.id.container)).perform(swipe(GeneralLocation.CENTER_LEFT,
+                GeneralLocation.CENTER_RIGHT));
+        assertThat(layoutManager.getChildAt(0).getLeft(), is(0));
+    }
+
+    @Test
+    @FlakyTest
+    public void testScrollAlongManAxis_direction_column() throws Throwable {
+        // This test verifies the scroll along the main axis if the height of the RecyclerView is
+        // larger than its parent when the main axis direction is vertical (column).
+        final FlexboxTestActivity activity = mActivityRule.getActivity();
+        final FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(activity);
+        final TestAdapter adapter = new TestAdapter();
+        mActivityRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setContentView(R.layout.wrapped_recyclerview_scroll_vertical);
+                RecyclerView recyclerView = (RecyclerView) activity.findViewById(R.id.recyclerview);
+                layoutManager.setFlexDirection(FlexDirection.COLUMN);
+                recyclerView.setLayoutManager(layoutManager);
+                recyclerView.setAdapter(adapter);
+                for (int i = 0; i < 50; i++) {
+                    FlexboxLayoutManager.LayoutParams lp = createLayoutParams(activity, 70, 100);
+                    adapter.addItem(lp);
+                }
+            }
+        });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        assertThat(layoutManager.getChildAt(0).getTop(), is(0));
+        onView(withId(R.id.container)).perform(swipe(GeneralLocation.BOTTOM_CENTER,
+                GeneralLocation.TOP_CENTER));
+        onView(withId(R.id.container)).perform(swipe(GeneralLocation.BOTTOM_CENTER,
+                GeneralLocation.TOP_CENTER));
+        onView(withId(R.id.container)).perform(swipe(GeneralLocation.BOTTOM_CENTER,
+                GeneralLocation.TOP_CENTER));
+        assertThat(layoutManager.getChildAt(0).getTop(), is(not(0)));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        onView(withId(R.id.container)).perform(swipe(GeneralLocation.TOP_CENTER,
+                GeneralLocation.BOTTOM_CENTER));
+        onView(withId(R.id.container)).perform(swipe(GeneralLocation.TOP_CENTER,
+                GeneralLocation.BOTTOM_CENTER));
+        onView(withId(R.id.container)).perform(swipe(GeneralLocation.TOP_CENTER,
+                GeneralLocation.BOTTOM_CENTER));
+        onView(withId(R.id.container)).perform(swipe(GeneralLocation.TOP_CENTER,
+                GeneralLocation.BOTTOM_CENTER));
+        assertThat(layoutManager.getChildAt(0).getTop(), is(0));
+    }
+
     /**
      * Creates a new flex item.
      *

--- a/flexbox/src/androidTest/res/layout/wrapped_recyclerview.xml
+++ b/flexbox/src/androidTest/res/layout/wrapped_recyclerview.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2017 Google Inc. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!-- Some APIs in espresso requires the view being performed is at least 90% visible to the
+     user, using the small width so that low resolution devices are covered-->
+<FrameLayout android:id="@+id/container"
+             xmlns:android="http://schemas.android.com/apk/res/android"
+             android:layout_width="320dp"
+             android:layout_height="240dp">
+    <android.support.v7.widget.RecyclerView android:id="@+id/recyclerview"
+                                            android:layout_width="600dp"
+                                            android:layout_height="match_parent"/>
+</FrameLayout>
+

--- a/flexbox/src/androidTest/res/layout/wrapped_recyclerview_scroll_vertical.xml
+++ b/flexbox/src/androidTest/res/layout/wrapped_recyclerview_scroll_vertical.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2017 Google Inc. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!-- Some APIs in espresso requires the view being performed is at least 90% visible to the
+     user, using the small width so that low resolution devices are covered-->
+<FrameLayout android:id="@+id/container"
+             xmlns:android="http://schemas.android.com/apk/res/android"
+             android:layout_width="320dp"
+             android:layout_height="240dp">
+    <android.support.v7.widget.RecyclerView android:id="@+id/recyclerview"
+                                            android:layout_width="match_parent"
+                                            android:layout_height="600dp"/>
+</FrameLayout>
+


### PR DESCRIPTION
This PR makes it available to let RecyclerView with FlexboxLayoutManager
scroll horizontally (when flexDirection is `row` or `row_reverse`. Vertically if it's set to `column` or `column_reverse` if the width of the RecyclerView is larger than its parent.)
(E.g. When the RecyclerView width is set to 800dp while the parent width
is 500dp)

This wasn't possible even wrap the RecyclerView with
HorizontalScrollView because in that case, the widthMeasureSpec is sent
as <width_of_parent> | View.MeasureSpec.UNSPECIFIED, thus the wrapping
doesn't happen regardless of the size of the flex line being processed.