### PR TITLE
Fix the invalid scroll with the following configuration

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.java
@@ -3250,6 +3250,8 @@ public class FlexboxLayoutManagerTest {
                 GeneralLocation.BOTTOM_CENTER));
         onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.TOP_CENTER,
                 GeneralLocation.BOTTOM_CENTER));
+        onView(withId(R.id.recyclerview)).perform(swipe(GeneralLocation.TOP_CENTER,
+                GeneralLocation.BOTTOM_CENTER));
         InstrumentationRegistry.getInstrumentation().waitForIdleSync();
 
         // Since a new item is inserted before the position, the index at the view who has the

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexLine.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexLine.java
@@ -31,16 +31,12 @@ public class FlexLine {
     FlexLine() {
     }
 
-    /** @see #getLeft() */
     int mLeft = Integer.MAX_VALUE;
 
-    /** @see #getTop() */
     int mTop = Integer.MAX_VALUE;
 
-    /** @see #getRight() */
     int mRight = Integer.MIN_VALUE;
 
-    /** @see #getBottom() */
     int mBottom = Integer.MIN_VALUE;
 
     /** @see #getMainSize() */


### PR DESCRIPTION
- flexDirection is column or column_reverse
- layout direction is RTL (e.g. language is set to RTL language)

If these conditions are met, the scroll direction is considered as
opposite since the start and end direction should be considered as
oppsite from the normal case.