### PR TITLE
Fix the issue that horizontal margins are ignored on devices with API level < 17 for the calculation to judge is a wrapping is required.

### DIFF
--- a/flexbox/src/androidTest/res/layout/activity_wrap_content_child_bottom_margin_column_grow.xml
+++ b/flexbox/src/androidTest/res/layout/activity_wrap_content_child_bottom_margin_column_grow.xml
@@ -29,6 +29,7 @@
         android:layout_width="24dp"
         android:layout_height="0dp"
         android:layout_marginEnd="12dp"
+        android:layout_marginRight="12dp"
         android:text="1"
         app:layout_flexBasisPercent="50%"
         app:layout_flexGrow="1"

--- a/flexbox/src/androidTest/res/layout/activity_wrap_content_child_bottom_margin_column_shrink.xml
+++ b/flexbox/src/androidTest/res/layout/activity_wrap_content_child_bottom_margin_column_shrink.xml
@@ -29,6 +29,7 @@
         android:layout_width="24dp"
         android:layout_height="150dp"
         android:layout_marginEnd="12dp"
+        android:layout_marginRight="12dp"
         android:text="1"
         app:layout_flexShrink="1" />
 

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
@@ -738,6 +738,11 @@ class FlexboxHelper {
 
     /**
      * Returns the flexItem's start margin in the main axis. Either start or top.
+     * For the backward compatibility for API level < 17, the horizontal margin is returned using
+     * {@link FlexItem#getMarginLeft} (ViewGroup.MarginLayoutParams#getMarginStart isn't available
+     * in API level < 17). Thus this method needs to be used with {@link #getFlexItemMarginEndMain}
+     * not to misuse the margin in RTL.
+     *
      *
      * @param flexItem         the flexItem
      * @param isMainHorizontal is the main axis horizontal
@@ -745,7 +750,7 @@ class FlexboxHelper {
      */
     private int getFlexItemMarginStartMain(FlexItem flexItem, boolean isMainHorizontal) {
         if (isMainHorizontal) {
-            return flexItem.getMarginStart();
+            return flexItem.getMarginLeft();
         }
 
         return flexItem.getMarginTop();
@@ -753,6 +758,10 @@ class FlexboxHelper {
 
     /**
      * Returns the flexItem's end margin in the main axis. Either end or bottom.
+     * For the backward compatibility for API level < 17, the horizontal margin is returned using
+     * {@link FlexItem#getMarginRight} (ViewGroup.MarginLayoutParams#getMarginEnd isn't available
+     * in API level < 17). Thus this method needs to be used with
+     * {@link #getFlexItemMarginStartMain} not to misuse the margin in RTL.
      *
      * @param flexItem         the flexItem
      * @param isMainHorizontal is the main axis horizontal
@@ -760,7 +769,7 @@ class FlexboxHelper {
      */
     private int getFlexItemMarginEndMain(FlexItem flexItem, boolean isMainHorizontal) {
         if (isMainHorizontal) {
-            return flexItem.getMarginEnd();
+            return flexItem.getMarginRight();
         }
 
         return flexItem.getMarginBottom();
@@ -768,6 +777,10 @@ class FlexboxHelper {
 
     /**
      * Returns the flexItem's start margin in the cross axis. Either start or top.
+     * For the backward compatibility for API level < 17, the horizontal margin is returned using
+     * {@link FlexItem#getMarginLeft} (ViewGroup.MarginLayoutParams#getMarginStart isn't available
+     * in API level < 17). Thus this method needs to be used with
+     * {@link #getFlexItemMarginEndCross} to not to misuse the margin in RTL.
      *
      * @param flexItem         the flexItem
      * @param isMainHorizontal is the main axis horizontal
@@ -778,11 +791,15 @@ class FlexboxHelper {
             return flexItem.getMarginTop();
         }
 
-        return flexItem.getMarginStart();
+        return flexItem.getMarginLeft();
     }
 
     /**
      * Returns the flexItem's end margin in the cross axis. Either end or bottom.
+     * For the backward compatibility for API level < 17, the horizontal margin is returned using
+     * {@link FlexItem#getMarginRight} (ViewGroup.MarginLayoutParams#getMarginEnd isn't available
+     * in API level < 17). Thus this method needs to be used with
+     * {@link #getFlexItemMarginStartCross} to not to misuse the margin in RTL.
      *
      * @param flexItem         the flexItem
      * @param isMainHorizontal is the main axis horizontal
@@ -793,7 +810,7 @@ class FlexboxHelper {
             return flexItem.getMarginBottom();
         }
 
-        return flexItem.getMarginEnd();
+        return flexItem.getMarginRight();
     }
 
     /**


### PR DESCRIPTION
Because the FlexboxHelper expected
ViewGroup.MarginLayoutParams#getMarginStart (getMarginEnd) methods when
calculating the wrap condition, which actually don't exist on API level < 17 devices.
Thus the horizontal margins are not taken into account for the calculation to judge if a line wrapping is required.

No devices are available on API level < 17  on Firebase Test Lab. So
manually ran the tests on an emulator with API level 16.

Fixes #353 