### PR TITLE
Remove unnecessary super method calls

### DIFF
--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
@@ -253,8 +253,6 @@ public class FlexboxLayout extends ViewGroup implements FlexContainer {
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-
         if (mOrderCache == null) {
             mOrderCache = new SparseIntArray(getChildCount());
         }


### PR DESCRIPTION
I think in `onMeasure`, you have calculated the child views and set the measurement based on the result of the calculation, then it is unnecessary to call the super method