### PR TITLE
Swapped the deprecated compile configuration for implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the following dependency to your `build.gradle` file:
 
 ```
 dependencies {
-    compile 'com.google.android:flexbox:0.3.2'
+    implementation 'com.google.android:flexbox:0.3.2'
 }
 ```
 


### PR DESCRIPTION
As of gradle 3.0 `compile` is deprecated and should be replace by `implementation`