### PR TITLE
Change the proguard rule from keep to dontobfuscate not to keep the

### DIFF
--- a/flexbox/proguard-rules.txt
+++ b/flexbox/proguard-rules.txt
@@ -17,4 +17,4 @@
 # The FlexboxLayoutManager may be set from a layout xml, in that situation the RecyclerView
 # tries to instantiate the layout manager using reflection.
 # This is to prevent the layout manager from being obfuscated.
--keep public class com.google.android.flexbox.FlexboxLayoutManager
+-keepnames public class com.google.android.flexbox.FlexboxLayoutManager


### PR DESCRIPTION
FlexboxLayoutManager in the binary even if it's not used.

Fixes 74417025 internally.