### PR TITLE
Fix the onItemsMoved animation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         minSdkVersion = 14
         targetSdkVersion = 27
         compileSdkVersion = 27
-        androidGradlePluginVersion = "3.0.1"
+        androidGradlePluginVersion = "3.1.3"
         androidMavenGradlePluginVersion = "1.5"
         gradleBintrayPluginVersion = "1.6"
         kotlinVersion = "1.2.30"

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayoutManager.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayoutManager.java
@@ -24,6 +24,7 @@ import android.graphics.PointF;
 import android.graphics.Rect;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.annotation.NonNull;
 import android.support.v4.view.ViewCompat;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.LinearSmoothScroller;
@@ -598,38 +599,37 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
     }
 
     @Override
-    public void onItemsAdded(RecyclerView recyclerView, int positionStart, int itemCount) {
+    public void onItemsAdded(@NonNull RecyclerView recyclerView, int positionStart, int itemCount) {
         super.onItemsAdded(recyclerView, positionStart, itemCount);
         updateDirtyPosition(positionStart);
     }
 
     @Override
-    public void onItemsUpdated(RecyclerView recyclerView, int positionStart, int itemCount,
+    public void onItemsUpdated(@NonNull RecyclerView recyclerView, int positionStart, int itemCount,
             Object payload) {
         super.onItemsUpdated(recyclerView, positionStart, itemCount, payload);
         updateDirtyPosition(positionStart);
     }
 
     @Override
-    public void onItemsUpdated(RecyclerView recyclerView, int positionStart, int itemCount) {
+    public void onItemsUpdated(@NonNull RecyclerView recyclerView, int positionStart, int itemCount) {
         super.onItemsUpdated(recyclerView, positionStart, itemCount);
         updateDirtyPosition(positionStart);
     }
 
     @Override
-    public void onItemsRemoved(RecyclerView recyclerView, int positionStart, int itemCount) {
+    public void onItemsRemoved(@NonNull RecyclerView recyclerView, int positionStart, int itemCount) {
         super.onItemsRemoved(recyclerView, positionStart, itemCount);
         updateDirtyPosition(positionStart);
     }
 
     @Override
-    public void onItemsMoved(RecyclerView recyclerView, int from, int to, int itemCount) {
+    public void onItemsMoved(@NonNull RecyclerView recyclerView, int from, int to, int itemCount) {
         super.onItemsMoved(recyclerView, from, to, itemCount);
         updateDirtyPosition(Math.min(from, to));
     }
 
     private void updateDirtyPosition(int positionStart) {
-        int firstVisiblePosition = findFirstVisibleItemPosition();
         int lastVisiblePosition = findLastVisibleItemPosition();
         if (positionStart >= lastVisiblePosition) {
             return;
@@ -648,9 +648,6 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
 
         View firstView = getChildClosestToStart();
         if (firstView == null) {
-            return;
-        }
-        if (firstVisiblePosition <= positionStart && positionStart <= lastVisiblePosition) {
             return;
         }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Nov 27 14:52:10 JST 2017
+#Thu Jul 19 22:58:08 JST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
Remove the unneeded guard condition in the updateDirtyPosition.
The mPendingScrollPosition (the position that is considered as the
starting point when the next layout starts) needed to be updated
regardless of the if statement of comparing
firstVisiblePosition and the positionStart

Fixes #439