### PR TITLE
Fixes the wrong positioning

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.kt
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.kt
@@ -3412,7 +3412,7 @@ class FlexboxLayoutManagerTest {
     @Test
     @FlakyTest
     @Throws(Throwable::class)
-    fun testNowrap_justifyContentCenter() {
+    fun testNowrap_justifyContentCenter_directionRow() {
         // This is to fix https://github.com/google/flexbox-layout/issues/469
         val activity = activityRule.activity
         val layoutManager = FlexboxLayoutManager(activity)
@@ -3432,12 +3432,43 @@ class FlexboxLayoutManagerTest {
             }
         }
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-        val view1Bottom= layoutManager.getChildAt(0)?.bottom ?: 0
-        val view2Bottom = layoutManager.getChildAt(1)?.bottom ?: 0
-        val view3Bottom = layoutManager.getChildAt(2)?.bottom ?: 0
+        val view1Bottom= layoutManager.getChildAt(0)!!.bottom
+        val view2Bottom = layoutManager.getChildAt(1)!!.bottom
+        val view3Bottom = layoutManager.getChildAt(2)!!.bottom
         assertThat(view1Bottom, `is`(activity.dpToPixel(height)))
         assertThat(view2Bottom, `is`(activity.dpToPixel(height)))
         assertThat(view3Bottom, `is`(activity.dpToPixel(height)))
+    }
+
+    @Test
+    @FlakyTest
+    @Throws(Throwable::class)
+    fun testNowrap_justifyContentCenter_directionColumn() {
+        // This is to fix https://github.com/google/flexbox-layout/issues/469
+        val activity = activityRule.activity
+        val layoutManager = FlexboxLayoutManager(activity)
+        val adapter = TestAdapter()
+        val width = 100
+        activityRule.runOnUiThread {
+            activity.setContentView(R.layout.recyclerview)
+            val recyclerView = activity.findViewById<RecyclerView>(R.id.recyclerview)
+            layoutManager.flexDirection = FlexDirection.COLUMN
+            layoutManager.flexWrap = FlexWrap.NOWRAP
+            layoutManager.justifyContent = JustifyContent.CENTER
+            recyclerView.layoutManager = layoutManager
+            recyclerView.adapter = adapter
+            for (i in 1..3) {
+                val lp = createLayoutParams(activity, width, 70)
+                adapter.addItem(lp)
+            }
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        val view1Right= layoutManager.getChildAt(0)!!.right
+        val view2Right = layoutManager.getChildAt(1)!!.right
+        val view3Right = layoutManager.getChildAt(2)!!.right
+        assertThat(view1Right, `is`(activity.dpToPixel(width)))
+        assertThat(view2Right, `is`(activity.dpToPixel(width)))
+        assertThat(view3Right, `is`(activity.dpToPixel(width)))
     }
 
     /**

--- a/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.kt
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/test/FlexboxLayoutManagerTest.kt
@@ -3409,6 +3409,37 @@ class FlexboxLayoutManagerTest {
         assertThat(layoutManager.flexLines.size, `is`(3))
     }
 
+    @Test
+    @FlakyTest
+    @Throws(Throwable::class)
+    fun testNowrap_justifyContentCenter() {
+        // This is to fix https://github.com/google/flexbox-layout/issues/469
+        val activity = activityRule.activity
+        val layoutManager = FlexboxLayoutManager(activity)
+        val adapter = TestAdapter()
+        val height = 70
+        activityRule.runOnUiThread {
+            activity.setContentView(R.layout.recyclerview)
+            val recyclerView = activity.findViewById<RecyclerView>(R.id.recyclerview)
+            layoutManager.flexDirection = FlexDirection.ROW
+            layoutManager.flexWrap = FlexWrap.NOWRAP
+            layoutManager.justifyContent = JustifyContent.CENTER
+            recyclerView.layoutManager = layoutManager
+            recyclerView.adapter = adapter
+            for (i in 1..3) {
+                val lp = createLayoutParams(activity, 100, height)
+                adapter.addItem(lp)
+            }
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        val view1Bottom= layoutManager.getChildAt(0)?.bottom ?: 0
+        val view2Bottom = layoutManager.getChildAt(1)?.bottom ?: 0
+        val view3Bottom = layoutManager.getChildAt(2)?.bottom ?: 0
+        assertThat(view1Bottom, `is`(activity.dpToPixel(height)))
+        assertThat(view2Bottom, `is`(activity.dpToPixel(height)))
+        assertThat(view3Bottom, `is`(activity.dpToPixel(height)))
+    }
+
     /**
      * Creates a new flex item.
      *

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayoutManager.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayoutManager.java
@@ -1895,18 +1895,27 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
 
     @Override
     public boolean canScrollHorizontally() {
-        return !isMainAxisDirectionHorizontal() || getWidth() > mParent.getWidth();
+        if (mFlexWrap == FlexWrap.NOWRAP) {
+            return isMainAxisDirectionHorizontal();
+        } else {
+            return !isMainAxisDirectionHorizontal() || getWidth() > mParent.getWidth();
+        }
     }
 
     @Override
     public boolean canScrollVertically() {
-        return isMainAxisDirectionHorizontal() || getHeight() > mParent.getHeight();
+        if (mFlexWrap == FlexWrap.NOWRAP) {
+            return !isMainAxisDirectionHorizontal();
+        } else {
+            return isMainAxisDirectionHorizontal() || getHeight() > mParent.getHeight();
+        }
     }
 
     @Override
     public int scrollHorizontallyBy(int dx, RecyclerView.Recycler recycler,
             RecyclerView.State state) {
-        if (!isMainAxisDirectionHorizontal()) {
+        if (!isMainAxisDirectionHorizontal() ||
+                (mFlexWrap == FlexWrap.NOWRAP && isMainAxisDirectionHorizontal())) {
             int scrolled = handleScrollingCrossAxis(dx, recycler, state);
             mViewCache.clear();
             return scrolled;
@@ -2873,17 +2882,38 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
                 // We need to use the anchor view as starting from right if the flex direction is
                 // (column or column_reverse) and layout direction is RTL.
                 if (mLayoutFromEnd) {
-                    mCoordinate = mOrientationHelper.getDecoratedStart(anchor) +
-                            mOrientationHelper.getTotalSpaceChange();
+                    // When the flex wrap is nowrap, the orientation helper is changed to
+                    // perpendicular. Need to use the mSubOrientationHelper to be consistent with
+                    // when flex wrap is not nowrap.
+                    if (mFlexWrap == FlexWrap.NOWRAP) {
+                        mCoordinate = mSubOrientationHelper.getDecoratedStart(anchor) +
+                                mSubOrientationHelper.getTotalSpaceChange();
+                    } else {
+                        mCoordinate = mOrientationHelper.getDecoratedStart(anchor) +
+                                mOrientationHelper.getTotalSpaceChange();
+                    }
                 } else {
-                    mCoordinate = mOrientationHelper.getDecoratedEnd(anchor);
+                    if (mFlexWrap == FlexWrap.NOWRAP) {
+                        mCoordinate = mSubOrientationHelper.getDecoratedEnd(anchor);
+                    } else {
+                        mCoordinate = mOrientationHelper.getDecoratedEnd(anchor);
+                    }
                 }
             } else {
                 if (mLayoutFromEnd) {
-                    mCoordinate = mOrientationHelper.getDecoratedEnd(anchor) +
-                            mOrientationHelper.getTotalSpaceChange();
+                    if (mFlexWrap == FlexWrap.NOWRAP) {
+                        mCoordinate = mSubOrientationHelper.getDecoratedEnd(anchor) +
+                                mSubOrientationHelper.getTotalSpaceChange();
+                    } else {
+                        mCoordinate = mOrientationHelper.getDecoratedEnd(anchor) +
+                                mOrientationHelper.getTotalSpaceChange();
+                    }
                 } else {
-                    mCoordinate = mOrientationHelper.getDecoratedStart(anchor);
+                    if (mFlexWrap == FlexWrap.NOWRAP) {
+                        mCoordinate = mSubOrientationHelper.getDecoratedStart(anchor);
+                    } else {
+                        mCoordinate = mOrientationHelper.getDecoratedStart(anchor);
+                    }
                 }
             }
             mPosition = getPosition(anchor);

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayoutManager.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayoutManager.java
@@ -789,7 +789,7 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
             gap = mOrientationHelper.getEndAfterPadding() - startOffset;
             if (gap > 0) {
                 // check if we should fix this gap.
-                fixOffset = handleScrollingCrossAxis(-gap, recycler, state);
+                fixOffset = handleScrollingMainOrientation(-gap, recycler, state);
             } else {
                 return 0; // nothing to fix
             }
@@ -797,7 +797,7 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
             gap = startOffset - mOrientationHelper.getStartAfterPadding();
             if (gap > 0) {
                 // check if we should fix this gap.
-                fixOffset = -handleScrollingCrossAxis(gap, recycler, state);
+                fixOffset = -handleScrollingMainOrientation(gap, recycler, state);
             } else {
                 return 0; // nothing to fix
             }
@@ -828,14 +828,14 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
         if (columnAndRtl) {
             gap = endOffset - mOrientationHelper.getStartAfterPadding();
             if (gap > 0) {
-                fixOffset = handleScrollingCrossAxis(gap, recycler, state);
+                fixOffset = handleScrollingMainOrientation(gap, recycler, state);
             } else {
                 return 0; // nothing to fix
             }
         } else {
             gap = mOrientationHelper.getEndAfterPadding() - endOffset;
             if (gap > 0) {
-                fixOffset = -handleScrollingCrossAxis(-gap, recycler, state);
+                fixOffset = -handleScrollingMainOrientation(-gap, recycler, state);
             } else {
                 return 0; // nothing to fix
             }
@@ -1916,11 +1916,11 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
             RecyclerView.State state) {
         if (!isMainAxisDirectionHorizontal() ||
                 (mFlexWrap == FlexWrap.NOWRAP && isMainAxisDirectionHorizontal())) {
-            int scrolled = handleScrollingCrossAxis(dx, recycler, state);
+            int scrolled = handleScrollingMainOrientation(dx, recycler, state);
             mViewCache.clear();
             return scrolled;
         } else {
-            int scrolled = handleScrollingMainAxis(dx);
+            int scrolled = handleScrollingSubOrientation(dx);
             mAnchorInfo.mPerpendicularCoordinate += scrolled;
             mSubOrientationHelper.offsetChildren(-scrolled);
             return scrolled;
@@ -1930,12 +1930,13 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
     @Override
     public int scrollVerticallyBy(int dy, RecyclerView.Recycler recycler,
             RecyclerView.State state) {
-        if (isMainAxisDirectionHorizontal()) {
-            int scrolled = handleScrollingCrossAxis(dy, recycler, state);
+        if (isMainAxisDirectionHorizontal() ||
+                (mFlexWrap == FlexWrap.NOWRAP && !isMainAxisDirectionHorizontal())) {
+            int scrolled = handleScrollingMainOrientation(dy, recycler, state);
             mViewCache.clear();
             return scrolled;
         } else {
-            int scrolled = handleScrollingMainAxis(dy);
+            int scrolled = handleScrollingSubOrientation(dy);
             mAnchorInfo.mPerpendicularCoordinate += scrolled;
             mSubOrientationHelper.offsetChildren(-scrolled);
             return scrolled;
@@ -1943,13 +1944,15 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
     }
 
     /**
+     * Handle the scrolling along the direction of {@link #mOrientationHelper}.
+     *
      * @param delta    the delta for the amount that is being scrolled
      *                 (either horizontally or vertically)
      * @param recycler the Recycler instance
      * @param state    the Recycler.State instance
      * @return the amount actually scrolled
      */
-    private int handleScrollingCrossAxis(int delta, RecyclerView.Recycler recycler,
+    private int handleScrollingMainOrientation(int delta, RecyclerView.Recycler recycler,
             RecyclerView.State state) {
         if (getChildCount() == 0 || delta == 0) {
             return 0;
@@ -1983,7 +1986,14 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
         return scrolled;
     }
 
-    private int handleScrollingMainAxis(int delta) {
+    /**
+     * Handle the scrolling along the direction of {@link #mSubOrientationHelper}.
+     *
+     * @param delta    the delta for the amount that is being scrolled
+     *                 (either horizontally or vertically)
+     * @return  the amount actually scrolled
+     */
+    private int handleScrollingSubOrientation(int delta) {
         if (getChildCount() == 0 || delta == 0) {
             return 0;
         }
@@ -2878,42 +2888,30 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
         }
 
         private void assignFromView(View anchor) {
+            OrientationHelper orientationHelper;
+            // When the flex wrap is nowrap, the orientation helper is changed to
+            // perpendicular. Need to use the mSubOrientationHelper to be consistent with
+            // when flex wrap is not nowrap.
+            if (mFlexWrap == FlexWrap.NOWRAP) {
+                orientationHelper = mSubOrientationHelper;
+            } else {
+                orientationHelper = mOrientationHelper;
+            }
             if (!isMainAxisDirectionHorizontal() && mIsRtl) {
                 // We need to use the anchor view as starting from right if the flex direction is
                 // (column or column_reverse) and layout direction is RTL.
                 if (mLayoutFromEnd) {
-                    // When the flex wrap is nowrap, the orientation helper is changed to
-                    // perpendicular. Need to use the mSubOrientationHelper to be consistent with
-                    // when flex wrap is not nowrap.
-                    if (mFlexWrap == FlexWrap.NOWRAP) {
-                        mCoordinate = mSubOrientationHelper.getDecoratedStart(anchor) +
-                                mSubOrientationHelper.getTotalSpaceChange();
-                    } else {
-                        mCoordinate = mOrientationHelper.getDecoratedStart(anchor) +
-                                mOrientationHelper.getTotalSpaceChange();
-                    }
+                    mCoordinate = orientationHelper.getDecoratedStart(anchor) +
+                        orientationHelper.getTotalSpaceChange();
                 } else {
-                    if (mFlexWrap == FlexWrap.NOWRAP) {
-                        mCoordinate = mSubOrientationHelper.getDecoratedEnd(anchor);
-                    } else {
-                        mCoordinate = mOrientationHelper.getDecoratedEnd(anchor);
-                    }
+                    mCoordinate = orientationHelper.getDecoratedEnd(anchor);
                 }
             } else {
                 if (mLayoutFromEnd) {
-                    if (mFlexWrap == FlexWrap.NOWRAP) {
-                        mCoordinate = mSubOrientationHelper.getDecoratedEnd(anchor) +
-                                mSubOrientationHelper.getTotalSpaceChange();
-                    } else {
-                        mCoordinate = mOrientationHelper.getDecoratedEnd(anchor) +
-                                mOrientationHelper.getTotalSpaceChange();
-                    }
+                    mCoordinate = orientationHelper.getDecoratedEnd(anchor) +
+                        orientationHelper.getTotalSpaceChange();
                 } else {
-                    if (mFlexWrap == FlexWrap.NOWRAP) {
-                        mCoordinate = mSubOrientationHelper.getDecoratedStart(anchor);
-                    } else {
-                        mCoordinate = mOrientationHelper.getDecoratedStart(anchor);
-                    }
+                    mCoordinate = orientationHelper.getDecoratedStart(anchor);
                 }
             }
             mPosition = getPosition(anchor);


### PR DESCRIPTION
On the condition flexWrap = No wrap and justifyContent = center.
This happened because when flexWrap = no wrap, the anchor position
retrieved from the existing view was wrong. Because the OrientationHelper
is changed to perpendicularly when flexWrap is nowrap.