### PR TITLE
Fixed issue #474, canScrollHorizontally() throws NPE 

### DIFF
--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayoutManager.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayoutManager.java
@@ -1898,7 +1898,7 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
         if (mFlexWrap == FlexWrap.NOWRAP) {
             return isMainAxisDirectionHorizontal();
         } else {
-            return !isMainAxisDirectionHorizontal() || getWidth() > mParent.getWidth();
+            return isMainAxisDirectionHorizontal() || getHeight() > (mParent != null ? mParent.getHeight() : 0);
         }
     }
 


### PR DESCRIPTION
Fixed issue 474, canScrollHorizontally() throws NPE if the RecyclerView is not attached to the Window