### PR TITLE
Fix the decoration is not included, when isWrapRequired is called.

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/FakeFlexContainer.kt
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/FakeFlexContainer.kt
@@ -148,4 +148,6 @@ internal class FakeFlexContainer : FlexContainer {
     override fun getFlexLinesInternal() = flexLines
 
     override fun updateViewCache(position: Int, view: View) = Unit
+
+    override fun calculateItemDecorationsForChild(child: View?) = Unit
 }

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexContainer.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexContainer.java
@@ -298,4 +298,15 @@ interface FlexContainer {
      * @param view     the view instance
      */
     void updateViewCache(int position, View view);
+
+    /**
+     * Calculates the item decor insets applied to the given child and updates the provided
+     *
+     * Note that item decorations are automatically calculated when one of the LayoutManager's
+     * measure child methods is called. If you need to measure the child with custom specs via
+     * {@link View#measure(int, int)}, you can use this method to get decorations.
+     *
+     * @param child The child view whose decorations should be calculated
+     */
+    void calculateItemDecorationsForChild(View child);
 }

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
@@ -881,6 +881,7 @@ class FlexboxHelper {
         if (maxLine != NOT_SET && maxLine <= flexLinesSize + 1) {
             return false;
         }
+        mFlexContainer.calculateItemDecorationsForChild(view);
         int decorationLength =
                 mFlexContainer.getDecorationLengthMainAxis(view, index, indexInFlexLine);
         if (decorationLength > 0) {

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
@@ -1328,6 +1328,11 @@ public class FlexboxLayout extends ViewGroup implements FlexContainer {
         // No op
     }
 
+    @Override
+    public void calculateItemDecorationsForChild(View child) {
+        // No op
+    }
+
     /**
      * @return the horizontal divider drawable that will divide each item.
      * @see #setDividerDrawable(Drawable)

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayoutManager.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayoutManager.java
@@ -533,6 +533,11 @@ public class FlexboxLayoutManager extends RecyclerView.LayoutManager implements 
     public void updateViewCache(int position, View view) {
         mViewCache.put(position, view);
     }
+
+    @Override
+    public void calculateItemDecorationsForChild(View child) {
+        calculateItemDecorationsForChild(child, TEMP_RECT);
+    }
     // The end of methods from FlexContainer
 
     // ScrollVectorProvider method


### PR DESCRIPTION
## Problem & How to solve
When the screen which is using FlexboxLayoutManager is rendered, FlexboxHelper#isWrapRequired is called. In that case, we are using RecyclerView, so the decoration length must be calculated, but it is not calculated in FlexboxHelper#isWrapRequired. So, I added calculateItemDecorationsForChild when FlexContainer has to calculate the decoration.

I know that calculateItemDecorationsForChild does not to be called in FlexLayout, but FlexLayout and FlexLayoutManager is abstracted with FlexContainer, so I could not find the way how distribute calculateItemDecorationsForChild function.

Welcome any comments.