### PR TITLE
Ensure flexbox layout row children can be as big as they want

### DIFF
--- a/flexbox/src/androidTest/java/com/google/android/flexbox/FlexboxHelperTest.kt
+++ b/flexbox/src/androidTest/java/com/google/android/flexbox/FlexboxHelperTest.kt
@@ -403,6 +403,27 @@ class FlexboxHelperTest {
 
     @Test
     @Throws(Throwable::class)
+    fun testDetermineMainSize_directionRow_unconstrainedWidth_childrenCanBeSizeTheyWant() {
+        val activity = activityRule.activity
+        val view1 = View(activity).apply {
+            layoutParams = FlexboxLayout.LayoutParams(100, 100)
+        }.also(flexContainer::addView)
+        val view2 = View(activity).apply {
+            layoutParams = FlexboxLayout.LayoutParams(1000, 100)
+        }.also(flexContainer::addView)
+        val widthMeasureSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+        val heightMeasureSpec = View.MeasureSpec.makeMeasureSpec(1000, View.MeasureSpec.UNSPECIFIED)
+        val result = FlexboxHelper.FlexLinesResult()
+        flexboxHelper.calculateHorizontalFlexLines(result, widthMeasureSpec, heightMeasureSpec)
+        flexContainer.flexLines = result.mFlexLines
+        flexboxHelper.determineMainSize(widthMeasureSpec, heightMeasureSpec)
+
+        assertThat(view1.measuredWidth, `is`(100))
+        assertThat(view2.measuredWidth, `is`(1000))
+    }
+
+    @Test
+    @Throws(Throwable::class)
     fun testDetermineMainSize_directionRow_considerCompoundButtonImplicitMinSizeWhenNotSpecified() {
         val containerWidth = 500
         val activity = activityRule.activity

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
@@ -975,8 +975,10 @@ class FlexboxHelper {
                 int largestMainSize = mFlexContainer.getLargestMainSize();
                 if (widthMode == View.MeasureSpec.EXACTLY) {
                     mainSize = widthSize;
-                } else {
+                } else if (widthMode == View.MeasureSpec.AT_MOST) {
                     mainSize = Math.min(largestMainSize, widthSize);
+                } else {
+                    mainSize = largestMainSize;
                 }
                 paddingAlongMainAxis = mFlexContainer.getPaddingLeft()
                         + mFlexContainer.getPaddingRight();


### PR DESCRIPTION
This PR addresses this issue https://github.com/google/flexbox-layout/issues/589, where `FlexboxLayout` row children are not visible when its width is unconstrained (such as when within a horizontal recycler view).