### PR TITLE
Preventing negative child width when shrinking on no wrap

### DIFF
--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
@@ -1273,6 +1273,10 @@ class FlexboxHelper {
                 if (!mChildrenFrozen[index] && flexItem.getFlexShrink() > 0f) {
                     float rawCalculatedWidth = childMeasuredWidth
                             - unitShrink * flexItem.getFlexShrink();
+                    if (rawCalculatedWidth < 0) {
+                        // Make sure no negative width when shrinking
+                        rawCalculatedWidth = 0;
+                    }
                     if (i == flexLine.mItemCount - 1) {
                         rawCalculatedWidth += accumulatedRoundError;
                         accumulatedRoundError = 0;


### PR DESCRIPTION
This minor change fixes an issue where a child view may have a negative width during shrinking in `no wrap` flex wrap mode.
If you look at the playground app, you will be able to reproduce it by setting the wrap mode to `no wrap`, and merely add more than 10 items. The horizontal `FlexLine` measurement going to be modified incorrectly due to a negative child view width. This may happen if a child view is already narrow and you force to shrink more.

| Issue before fix | Correct behavior after fix |
|---|---|
| ![no-wrap-shrinking-issue-negative-child-measure-width](https://github.com/google/flexbox-layout/assets/11421161/931b5167-a0cf-4b4e-8a68-fbb8cee94bbd) | ![no-wrap-shrinking-fix-negative-child-measure-width](https://github.com/google/flexbox-layout/assets/11421161/4b9ad7e7-b791-4d97-8e83-040d906fd734) |